### PR TITLE
AI toys (Claude Chat + Research Agent), SEO/GEO, and prerendering

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -11,8 +11,9 @@
     {
       "name": "preview",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "preview"],
-      "port": 4173
+      "runtimeArgs": ["run", "preview", "--", "--port", "4188"],
+      "port": 4188,
+      "autoPort": false
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ Thumbs.db
 .cache/
 .parcel-cache/
 .vite/
+
+# SSR prerender output (build artifact)
+dist-server/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Personal site (zkevinbai.com): React 18 + Vite + Tailwind 3 + react-router-dom 6
 
 - Content is data-driven: edit the arrays/data files (`blogData.js`, `toysData.js`, arrays at the top of Portfolio components), not markup, to change content.
 - New toy = component in `src/features/Toys/tools/` + entry in `toysData.js`. Use `toykit.jsx` helpers for consistent UI.
+- `Claude Chat` (`/toys/claude-chat`) calls the Anthropic API directly from the browser (lazy-loaded so the SDK only ships on that page). Its key comes from `VITE_ANTHROPIC_API_KEY` in `.env.local` (local dev only — gitignored, never bundled into the GitHub Pages build) or a key the visitor pastes (kept in `localStorage`). There is no backend; don't commit a key or assume one server-side.
 - `/themes` (Theme Studio) is an intentional easter egg — keep it.
 - Analytics: wrap user-facing interactions with the helpers in `src/utils/analytics.js`; they no-op without gtag.
 

--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -16,9 +16,9 @@ Defined in `src/App.jsx`:
 | `/projects` | `ProjectsPage` | Standalone projects page |
 | `/blog` | `AllBlogs` | Blog index |
 | `/blog/:slug` | `SingleBlog` | One post |
-| `/toys` | `Toys` | Browser-utility index |
+| `/toys` | `Toys` | Index of browser utilities + AI experiments |
 | `/toys/zodiac` | `ChineseZodiac` | Zodiac lookup (a "toy") |
-| `/toys/:slug` | `ToyPage` | One tool |
+| `/toys/:slug` | `ToyPage` | One toy |
 | `/themes` | `Themes` | Theme Studio — intentional easter egg, linked from the footer |
 | `/zodiac` | redirect → `/toys/zodiac` | Backward compat |
 | `*` | redirect → `/` | Catch-all |
@@ -41,7 +41,8 @@ src/
     │                        Projects, Education, Skills, Section (wrapper)
     ├── Blog/                AllBlogs, SingleBlog, blogData.js
     ├── Toys/                Toys index, ToyPage, ToyLayout, toykit.jsx,
-    │                        toysData.js, tools/ (one file per tool)
+    │                        toysData.js, tools/ (one file per toy; Claude Chat
+    │                        calls the Anthropic API directly from the browser)
     ├── ChineseZodiac/       Zodiac feature, zodiacData.js, zodiacUtils.js
     └── Themes/              Theme Studio page, themePresets.js (dark mode vars)
 ```
@@ -51,7 +52,7 @@ src/
 Content is data-driven, no CMS:
 
 - Blog posts live in `src/features/Blog/blogData.js` as HTML strings. Legacy posts carry old inline classes; `SingleBlog.jsx` strips every `class="…"` before rendering and `.prose` in `index.css` styles by tag. New posts can omit inline classes entirely.
-- Toys are registered in `src/features/Toys/toysData.js` (slug, category, component). Adding a tool = new file in `tools/` + one entry there.
+- Toys are registered in `src/features/Toys/toysData.js` (slug, category, component). Adding a toy = new file in `tools/` + one entry there.
 - Career/education/project content lives in arrays at the top of the respective Portfolio components.
 - Zodiac tables live in `zodiacData.js` / `zodiacUtils.js`.
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#fbf7f0" />
     <meta name="description" content="Member of Technical Staff at Anthropic — Forward Deployed Engineering, Applied AI, and International Relations." />
+    <meta name="author" content="Kevin Bai" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <link rel="canonical" href="https://zkevinbai.com/" />
 
     <!-- Apply saved theme before paint to avoid a flash. Default is light;
          dark only when the visitor has explicitly opted in (ignore OS setting). -->
@@ -24,6 +27,7 @@
     
     <!-- Open Graph / Facebook / iMessage -->
     <meta property="og:type" content="website" />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:url" content="https://zkevinbai.com/" />
     <meta property="og:site_name" content="Kevin Bai" />
     <meta property="og:title" content="Kevin Bai — Member of Technical Staff, Anthropic" />
@@ -46,7 +50,53 @@
     <meta name="twitter:description" content="Forward Deployed Engineering, Applied AI, and International Relations. Previously Palantir, the United Nations, Berkeley, and Oxford." />
     <meta name="twitter:image" content="https://zkevinbai.com/og-image.jpg?v=2" />
     
-    <title>Kevin Bai</title>
+    <title>Kevin Bai — Member of Technical Staff, Anthropic</title>
+
+    <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
+
+    <!-- Structured data: identity + site. Read by search engines and AI/answer
+         engines to understand who this site is about. Kept in the static HTML so
+         crawlers that don't execute JavaScript still see it. -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Person",
+          "@id": "https://zkevinbai.com/#person",
+          "name": "Kevin Bai",
+          "url": "https://zkevinbai.com/",
+          "image": "https://zkevinbai.com/og-image.jpg?v=2",
+          "jobTitle": "Member of Technical Staff",
+          "worksFor": { "@type": "Organization", "name": "Anthropic" },
+          "alumniOf": [
+            { "@type": "CollegeOrUniversity", "name": "University of California, Berkeley" },
+            { "@type": "CollegeOrUniversity", "name": "University of Oxford" }
+          ],
+          "knowsAbout": [
+            "Forward Deployed Engineering",
+            "Applied AI",
+            "Enterprise Software",
+            "International Relations"
+          ],
+          "sameAs": [
+            "https://www.linkedin.com/in/zkevinbai/",
+            "https://github.com/zkevinbai",
+            "https://twitter.com/zkevinbai"
+          ]
+        },
+        {
+          "@type": "WebSite",
+          "@id": "https://zkevinbai.com/#website",
+          "url": "https://zkevinbai.com/",
+          "name": "Kevin Bai",
+          "description": "Member of Technical Staff at Anthropic — Forward Deployed Engineering, Applied AI, and International Relations.",
+          "inLanguage": "en",
+          "publisher": { "@id": "https://zkevinbai.com/#person" }
+        }
+      ]
+    }
+    </script>
 
     <!-- Google Fonts: Fraunces (editorial serif) + Inter (sans) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bucephalus",
       "version": "0.3.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.105.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.20.0",
@@ -31,6 +32,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.105.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.105.0.tgz",
+      "integrity": "sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -444,6 +473,11 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -817,6 +851,11 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -1035,6 +1074,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1964,6 +2015,15 @@
         "sql-formatter": "bin/sql-formatter-cli.cjs"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -2229,6 +2289,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/gen-seo.mjs && (vite build --ssr src/entry-server.jsx --outDir dist-server --logLevel error && node scripts/prerender.mjs || echo 'prerender skipped — shipping SPA build')",
     "preview": "vite preview"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.105.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,40 @@
+# zkevinbai.com — open to search and answer engines.
+
+User-agent: *
+Allow: /
+
+# Generative / answer engines — explicitly welcomed so the site can be cited.
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+Sitemap: https://zkevinbai.com/sitemap.xml

--- a/scripts/gen-seo.mjs
+++ b/scripts/gen-seo.mjs
@@ -1,0 +1,99 @@
+/**
+ * Post-build SEO generator. Runs after `vite build` and writes machine-readable
+ * discovery files into dist/:
+ *   - sitemap.xml  — every indexable URL, with blog lastmod dates
+ *   - llms.txt     — a Markdown map of the site for AI / answer engines (GEO)
+ *
+ * Content is derived entirely from existing site data (blog posts, the toy
+ * registry, route list) — it summarizes what's already on the site, it doesn't
+ * author anything new.
+ */
+import { readFile, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const dist = resolve(root, 'dist')
+const SITE = 'https://zkevinbai.com'
+
+const isoDate = (human) => {
+  const d = new Date(human)
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString().slice(0, 10)
+}
+const esc = (s) =>
+  String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+
+// --- Blog posts (plain-JS module, safe to import) ---------------------------
+const { blogPosts } = await import(resolve(root, 'src/features/Blog/blogData.js'))
+
+// --- Toys (toysData.js imports JSX components, so parse slugs/names from text)
+const toysSrc = await readFile(resolve(root, 'src/features/Toys/toysData.js'), 'utf8')
+const toys = []
+const re = /slug:\s*'([^']+)',\s*\n\s*name:\s*'([^']+)',\s*\n\s*blurb:\s*'([^']*)'/g
+let m
+while ((m = re.exec(toysSrc))) {
+  toys.push({ slug: m[1], name: m[2], blurb: m[3] })
+}
+
+// --- URL set ----------------------------------------------------------------
+const staticPages = [
+  { path: '/', priority: '1.0', changefreq: 'monthly' },
+  { path: '/blog', priority: '0.8', changefreq: 'weekly' },
+  { path: '/projects', priority: '0.6', changefreq: 'yearly' },
+  { path: '/curiosities', priority: '0.4', changefreq: 'yearly' },
+]
+const toyUrls = toys.map((t) => ({
+  path: t.slug === 'zodiac' ? '/toys/zodiac' : `/toys/${t.slug}`,
+  priority: '0.6',
+  changefreq: 'monthly',
+}))
+const toysIndex = [{ path: '/toys', priority: '0.7', changefreq: 'monthly' }]
+const postUrls = blogPosts.map((p) => ({
+  path: `/blog/${p.slug}`,
+  priority: '0.7',
+  changefreq: 'yearly',
+  lastmod: isoDate(p.date),
+}))
+
+const urls = [...staticPages, ...toysIndex, ...toyUrls, ...postUrls]
+
+// --- sitemap.xml ------------------------------------------------------------
+const sitemap =
+  `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+  urls
+    .map(
+      (u) =>
+        `  <url>\n    <loc>${SITE}${u.path}</loc>\n` +
+        (u.lastmod ? `    <lastmod>${u.lastmod}</lastmod>\n` : '') +
+        `    <changefreq>${u.changefreq}</changefreq>\n    <priority>${u.priority}</priority>\n  </url>`
+    )
+    .join('\n') +
+  `\n</urlset>\n`
+
+await writeFile(resolve(dist, 'sitemap.xml'), sitemap)
+
+// --- llms.txt (GEO) ---------------------------------------------------------
+const llms =
+  `# Kevin Bai\n\n` +
+  `> Member of Technical Staff at Anthropic — Forward Deployed Engineering, Applied AI, ` +
+  `and International Relations. Previously Palantir, the United Nations, Berkeley, and Oxford. ` +
+  `Personal site at ${SITE}.\n\n` +
+  `## Key pages\n\n` +
+  `- [Home / about](${SITE}/): who Kevin is, career timeline, education, and skills.\n` +
+  `- [Writing](${SITE}/blog): essays on forward deployed engineering, enterprise software, and geopolitics.\n` +
+  `- [Toys](${SITE}/toys): small browser tools and AI experiments.\n` +
+  `- [Projects](${SITE}/projects): selected work.\n\n` +
+  `## Writing\n\n` +
+  blogPosts
+    .map((p) => `- [${p.title}](${SITE}/blog/${p.slug}): ${p.excerpt}`)
+    .join('\n') +
+  `\n\n## Toys\n\n` +
+  toys.map((t) => `- [${t.name}](${SITE}${t.slug === 'zodiac' ? '/toys/zodiac' : `/toys/${t.slug}`}): ${t.blurb}`).join('\n') +
+  `\n`
+
+await writeFile(resolve(dist, 'llms.txt'), llms)
+
+console.log(
+  `[gen-seo] wrote sitemap.xml (${urls.length} urls) and llms.txt (${blogPosts.length} posts, ${toys.length} toys)`
+)

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,93 @@
+/**
+ * Build-time prerendering for content routes. Runs after the client build, the
+ * SSR build, and gen-seo. For each high-value route it server-renders the app to
+ * HTML and writes a static dist/<route>/index.html with the content baked in plus
+ * route-specific <head> metadata + JSON-LD — so crawlers that don't run JS (some
+ * AI/answer engines) and first paint both get real content.
+ *
+ * Every route is best-effort: a failure logs and is skipped, leaving the normal
+ * SPA fallback for that route. The build never fails because of prerendering.
+ */
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const dist = resolve(root, 'dist')
+const SITE = 'https://zkevinbai.com'
+
+const escAttr = (s = '') =>
+  String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+const escText = (s = '') => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+const { render } = await import(resolve(root, 'dist-server/entry-server.js'))
+const { blogPosts } = await import(resolve(root, 'src/features/Blog/blogData.js'))
+const { articleJsonLd, blogJsonLd } = await import(resolve(root, 'src/utils/seo.js'))
+
+const template = await readFile(resolve(dist, 'index.html'), 'utf8')
+
+const BLOG_DESC =
+  'Thoughts on forward deployed engineering, enterprise software, international geopolitics and economics, and building technology that solves real problems.'
+
+const routes = [
+  {
+    path: '/',
+    title: 'Kevin Bai — Member of Technical Staff, Anthropic',
+    desc: 'Forward Deployed Engineering, Applied AI, and International Relations. Previously Palantir, the United Nations, Berkeley, and Oxford.',
+    type: 'profile',
+  },
+  { path: '/blog', title: 'Writing — Kevin Bai', desc: BLOG_DESC, jsonLd: blogJsonLd(blogPosts) },
+  ...blogPosts.map((p) => ({
+    path: `/blog/${p.slug}`,
+    title: `${p.title} — Kevin Bai`,
+    desc: p.excerpt,
+    type: 'article',
+    jsonLd: articleJsonLd(p),
+  })),
+  { path: '/projects', title: 'Projects — Kevin Bai', desc: 'Selected projects and things Kevin Bai has built.' },
+  { path: '/curiosities', title: 'Curiosities — Kevin Bai', desc: 'Off-the-main-path corners of zkevinbai.com.' },
+]
+
+function injectHead(html, r) {
+  const url = SITE + r.path
+  const sub = (re, value) => {
+    html = html.replace(re, value)
+  }
+  sub(/<title>[\s\S]*?<\/title>/, `<title>${escText(r.title)}</title>`)
+  sub(/(<meta name="description" content=")[^"]*(")/, `$1${escAttr(r.desc)}$2`)
+  sub(/(<link rel="canonical" href=")[^"]*(")/, `$1${url}$2`)
+  sub(/(<meta property="og:title" content=")[^"]*(")/, `$1${escAttr(r.title)}$2`)
+  sub(/(<meta property="og:description" content=")[^"]*(")/, `$1${escAttr(r.desc)}$2`)
+  sub(/(<meta property="og:url" content=")[^"]*(")/, `$1${url}$2`)
+  sub(/(<meta property="og:type" content=")[^"]*(")/, `$1${r.type || 'website'}$2`)
+  sub(/(<meta name="twitter:title" content=")[^"]*(")/, `$1${escAttr(r.title)}$2`)
+  sub(/(<meta name="twitter:description" content=")[^"]*(")/, `$1${escAttr(r.desc)}$2`)
+  sub(/(<meta name="twitter:url" content=")[^"]*(")/, `$1${url}$2`)
+  if (r.jsonLd) {
+    html = html.replace(
+      '</head>',
+      `  <script type="application/ld+json">${JSON.stringify(r.jsonLd)}</script>\n  </head>`
+    )
+  }
+  return html
+}
+
+let ok = 0
+let skipped = 0
+for (const r of routes) {
+  try {
+    const appHtml = render(r.path)
+    if (!appHtml || !appHtml.trim()) throw new Error('empty render')
+    let page = injectHead(template, r)
+    page = page.replace('<div id="root"></div>', `<div id="root">${appHtml}</div>`)
+    const outDir = r.path === '/' ? dist : resolve(dist, '.' + r.path)
+    await mkdir(outDir, { recursive: true })
+    await writeFile(resolve(outDir, 'index.html'), page)
+    ok++
+  } catch (err) {
+    skipped++
+    console.warn(`[prerender] skipped ${r.path}: ${err.message}`)
+  }
+}
+
+console.log(`[prerender] prerendered ${ok} routes${skipped ? `, skipped ${skipped}` : ''}`)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { useEffect } from 'react'
 import Header from './components/Header'
 import Footer from './components/Footer'
@@ -37,7 +37,7 @@ function RouteEffects() {
 
 function App() {
   return (
-    <BrowserRouter>
+    <>
       <RouteEffects />
       <Header />
       <main className="min-h-screen">
@@ -58,7 +58,7 @@ function App() {
         </Routes>
       </main>
       <Footer />
-    </BrowserRouter>
+    </>
   )
 }
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,9 +4,14 @@ import { trackThemeToggle } from '../utils/analytics'
 
 export default function Header() {
   const [scrolled, setScrolled] = useState(false)
-  const [dark, setDark] = useState(
-    () => typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
-  )
+  // Start light to match the server-prerendered markup, then sync to the real
+  // theme on mount — keeps hydration clean (the inline script applies the theme
+  // to <html> before React; this just brings the toggle icon in line).
+  const [dark, setDark] = useState(false)
+
+  useEffect(() => {
+    setDark(document.documentElement.classList.contains('dark'))
+  }, [])
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 8)

--- a/src/entry-server.jsx
+++ b/src/entry-server.jsx
@@ -1,0 +1,12 @@
+import { renderToString } from 'react-dom/server'
+import { StaticRouter } from 'react-router-dom/server'
+import App from './App.jsx'
+
+/** Render the app for one route to an HTML string (build-time prerendering). */
+export function render(url) {
+  return renderToString(
+    <StaticRouter location={url}>
+      <App />
+    </StaticRouter>
+  )
+}

--- a/src/features/Blog/AllBlogs.jsx
+++ b/src/features/Blog/AllBlogs.jsx
@@ -3,8 +3,17 @@ import Container from '../../components/Container'
 import { SubstackBlogBand } from '../../components/SubstackCTA'
 import { blogPosts } from './blogData'
 import { trackBlogPostClick } from '../../utils/analytics'
+import { useSeo, blogJsonLd } from '../../utils/seo'
 
 export default function AllBlogs() {
+  useSeo({
+    title: 'Writing — Kevin Bai',
+    description:
+      'Thoughts on forward deployed engineering, enterprise software, international geopolitics and economics, and building technology that solves real problems.',
+    path: '/blog',
+    jsonLd: blogJsonLd(blogPosts),
+  })
+
   return (
     <Container size="reading" className="pt-32 pb-8 md:pt-40">
       <header className="reveal">

--- a/src/features/Blog/SingleBlog.jsx
+++ b/src/features/Blog/SingleBlog.jsx
@@ -4,6 +4,7 @@ import Container from '../../components/Container'
 import { SubstackPostCTA } from '../../components/SubstackCTA'
 import { getPostBySlug, blogPosts } from './blogData'
 import { trackBlogPostView } from '../../utils/analytics'
+import { useSeo, articleJsonLd } from '../../utils/seo'
 
 // The blog content carries legacy inline class attributes (font-raleway, gray
 // utilities, etc.). Strip them so the `.prose` layer styles it by tag instead.
@@ -28,6 +29,18 @@ export default function SingleBlog() {
   useEffect(() => {
     if (post) trackBlogPostView({ slug, title: post.title, category: post.category })
   }, [slug, post])
+
+  useSeo(
+    post
+      ? {
+          title: `${post.title} — Kevin Bai`,
+          description: post.excerpt,
+          path: `/blog/${post.slug}`,
+          type: 'article',
+          jsonLd: articleJsonLd(post),
+        }
+      : { title: 'Post not found — Kevin Bai', path: `/blog/${slug}`, robots: 'noindex, follow' }
+  )
 
   if (!post) {
     return (

--- a/src/features/ChineseZodiac/ChineseZodiac.jsx
+++ b/src/features/ChineseZodiac/ChineseZodiac.jsx
@@ -6,10 +6,22 @@ import YearTable from './YearTable'
 import YearDetail from './YearDetail'
 import { isValidYear, findYearByCombination } from './zodiacUtils'
 import { trackToyUse } from '../../utils/analytics'
+import { useSeo, softwareJsonLd } from '../../utils/seo'
 
 export default function ChineseZodiac() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [selectedYear, setSelectedYear] = useState(null)
+
+  useSeo({
+    title: 'Chinese Zodiac — Kevin Bai',
+    description: 'Look up any year’s Chinese zodiac animal and element, and what they mean.',
+    path: '/toys/zodiac',
+    jsonLd: softwareJsonLd({
+      name: 'Chinese Zodiac',
+      description: 'Look up any year’s Chinese zodiac animal and element, and what they mean.',
+      path: '/toys/zodiac',
+    }),
+  })
 
   // Read URL parameters on mount and when they change
   useEffect(() => {

--- a/src/features/Curiosities/Curiosities.jsx
+++ b/src/features/Curiosities/Curiosities.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import Container from '../../components/Container'
 import { trackEasterEgg } from '../../utils/analytics'
+import { useSeo } from '../../utils/seo'
 
 // A quiet hub for the off-the-main-path corners of the site, reached from the
 // footer easter egg. Each card routes onward to its own page.
@@ -29,6 +30,12 @@ const corners = [
 ]
 
 export default function Curiosities() {
+  useSeo({
+    title: 'Curiosities — Kevin Bai',
+    description: 'Off-the-main-path corners of zkevinbai.com.',
+    path: '/curiosities',
+  })
+
   return (
     <Container size="reading" className="pt-28 pb-16 md:pt-36">
       <Link

--- a/src/features/LogoSizer/LogoSizer.jsx
+++ b/src/features/LogoSizer/LogoSizer.jsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import Container from '../../components/Container'
+import { useSeo } from '../../utils/seo'
 import AnthropicLogo from '../../assets/companies/Anthropic-logo.svg'
 import RipplingLogo from '../../assets/companies/Rippling-logo.png'
 import GlobalityLogo from '../../assets/companies/Globality-logo.png'
@@ -30,6 +31,13 @@ function Chip({ src, bg, pad, size }) {
 
 export default function LogoSizer() {
   const [pad, setPad] = useState(8)
+
+  useSeo({
+    title: 'Logo Sizer — Kevin Bai',
+    description: 'An interactive toy for sizing the logo chips in the career timeline.',
+    path: '/logo-sizer',
+    robots: 'noindex, follow',
+  })
 
   return (
     <Container size="reading" className="pt-28 pb-20 md:pt-36">

--- a/src/features/Portfolio/CareerTimeline.jsx
+++ b/src/features/Portfolio/CareerTimeline.jsx
@@ -100,9 +100,9 @@ const careerEntries = [
     dateRange: '2025 — 2026',
     location: 'San Francisco Bay Area',
     bullets: [
-      'Founding <strong>Forward Deployed Engineer</strong> at Rippling, <strong>first hire</strong>. Helped build the <strong>FDE function</strong> — a Forward Deployed Engineer is part consultant, part product manager, and part software engineer: a <strong>founder-shaped engineer</strong>',
-      "Solved <strong>enterprise problems</strong> for Rippling's <strong>largest and most strategic customers</strong>. If there wasn't a SKU we needed, we invented it. Our north star was the success of our customers on Rippling",
-      'Created the <strong>Slack channel and GitHub repo</strong>, authored the <strong>first FDE SOPs</strong>, completed the <strong>first FDE project</strong>, and wrote the <strong>first 250K lines of FDE code</strong>',
+      '🌱 Founding <strong>Forward Deployed Engineer</strong> at Rippling, <strong>first hire</strong>. Helped build the <strong>FDE function</strong> — part consultant, part product manager, part software engineer: a <strong>founder-shaped engineer</strong> — and grew the team by <strong>interviewing and hiring</strong> FDEs',
+      "🎯 Solved <strong>enterprise problems</strong> for Rippling's <strong>largest and most strategic customers</strong>. If there was a SKU the customer needed that Rippling did not have, we invented it. Our north star was the success of our customers on Rippling",
+      '🛠️ Created the <strong>Slack channel and GitHub repo</strong>, authored the <strong>first FDE SOPs</strong>, and wrote the <strong>first 250K lines of FDE code</strong> — then built <strong>Rippling’s MCP server</strong> and <strong>10+ Skills</strong> to multiply <strong>FDE output</strong> and developer experience',
     ],
   },
   {

--- a/src/features/Portfolio/Portfolio.jsx
+++ b/src/features/Portfolio/Portfolio.jsx
@@ -6,8 +6,17 @@ import Volunteering from './Volunteering'
 import Education from './Education'
 import Skills from './Skills'
 import { SubstackHomeBand } from '../../components/SubstackCTA'
+import { useSeo } from '../../utils/seo'
 
 export default function Portfolio() {
+  useSeo({
+    title: 'Kevin Bai — Member of Technical Staff, Anthropic',
+    description:
+      'Forward Deployed Engineering, Applied AI, and International Relations. Previously Palantir, the United Nations, Berkeley, and Oxford.',
+    path: '/',
+    type: 'profile',
+  })
+
   return (
     <>
       <Hero />

--- a/src/features/Portfolio/ProjectsPage.jsx
+++ b/src/features/Portfolio/ProjectsPage.jsx
@@ -1,10 +1,17 @@
 import { Link } from 'react-router-dom'
 import Container from '../../components/Container'
 import Projects from './Projects'
+import { useSeo } from '../../utils/seo'
 
 /** Standalone home for the retired Projects section — reachable from the
     footer easter egg, off the main portfolio scroll. */
 export default function ProjectsPage() {
+  useSeo({
+    title: 'Projects — Kevin Bai',
+    description: 'Selected projects and things Kevin Bai has built.',
+    path: '/projects',
+  })
+
   return (
     <div className="pt-20 md:pt-24">
       <Container size="page">

--- a/src/features/Themes/Themes.jsx
+++ b/src/features/Themes/Themes.jsx
@@ -1,5 +1,6 @@
 import Container from '../../components/Container'
 import { themes } from './themePresets'
+import { useSeo } from '../../utils/seo'
 
 const serif = "'Fraunces', Georgia, serif"
 
@@ -158,6 +159,13 @@ function ThemeCard({ t }) {
 }
 
 export default function Themes() {
+  useSeo({
+    title: 'Theme Studio — Kevin Bai',
+    description: 'Preview the color palettes behind zkevinbai.com.',
+    path: '/themes',
+    robots: 'noindex, follow',
+  })
+
   return (
     <Container size="page" className="pt-32 pb-8 md:pt-40">
       <header className="reveal max-w-reading">

--- a/src/features/Toys/ToyPage.jsx
+++ b/src/features/Toys/ToyPage.jsx
@@ -1,9 +1,10 @@
 import { useParams, Link } from 'react-router-dom'
-import { useEffect } from 'react'
+import { Suspense, useEffect } from 'react'
 import Container from '../../components/Container'
 import ToyLayout from './ToyLayout'
 import { getToy } from './toysData'
 import { trackEvent } from '../../utils/analytics'
+import { useSeo, softwareJsonLd } from '../../utils/seo'
 
 export default function ToyPage() {
   const { slug } = useParams()
@@ -12,6 +13,17 @@ export default function ToyPage() {
   useEffect(() => {
     if (toy?.Component) trackEvent('toy_open', { toy_slug: toy.slug, toy_name: toy.name })
   }, [toy])
+
+  useSeo(
+    toy?.Component
+      ? {
+          title: `${toy.name} — Kevin Bai`,
+          description: toy.blurb,
+          path: `/toys/${toy.slug}`,
+          jsonLd: softwareJsonLd({ name: toy.name, description: toy.blurb, path: `/toys/${toy.slug}` }),
+        }
+      : { title: 'Toy not found — Kevin Bai', path: `/toys/${slug}`, robots: 'noindex, follow' }
+  )
 
   if (!toy || !toy.Component) {
     return (
@@ -27,7 +39,9 @@ export default function ToyPage() {
   const { Component } = toy
   return (
     <ToyLayout toy={toy}>
-      <Component />
+      <Suspense fallback={<p className="text-sm text-muted">Loading…</p>}>
+        <Component />
+      </Suspense>
     </ToyLayout>
   )
 }

--- a/src/features/Toys/Toys.jsx
+++ b/src/features/Toys/Toys.jsx
@@ -1,9 +1,22 @@
 import { Link } from 'react-router-dom'
 import Container from '../../components/Container'
-import { toysByCategory } from './toysData'
+import { toys, toysByCategory } from './toysData'
+import { useSeo, collectionJsonLd } from '../../utils/seo'
 
 export default function Toys() {
   const groups = toysByCategory()
+
+  useSeo({
+    title: 'Toys — Kevin Bai',
+    description:
+      'A workshop shelf of little browser tools, AI experiments, and curiosities. Most run entirely on your device; the ones that talk to an API say so.',
+    path: '/toys',
+    jsonLd: collectionJsonLd({
+      name: 'Toys — Kevin Bai',
+      path: '/toys',
+      items: toys.map((t) => ({ name: t.name, path: t.path || `/toys/${t.slug}` })),
+    }),
+  })
 
   return (
     <Container size="page" className="pt-32 pb-8 md:pt-40">
@@ -13,8 +26,8 @@ export default function Toys() {
           Small things I built for fun.
         </h1>
         <p className="mt-5 text-[1.1rem] leading-relaxed text-muted">
-          A workshop shelf of little browser tools and curiosities. Everything runs entirely on
-          your device — nothing you type ever leaves the page.
+          A workshop shelf of little browser tools, AI experiments, and curiosities. Most run
+          entirely on your device; the ones that talk to an API say so.
         </p>
       </header>
 
@@ -30,7 +43,7 @@ export default function Toys() {
                 {category}
               </h2>
               <span className="font-serif text-sm italic text-muted md:mt-1 md:block">
-                {items.length} {items.length === 1 ? 'tool' : 'tools'}
+                {items.length} {items.length === 1 ? 'toy' : 'toys'}
               </span>
             </div>
 

--- a/src/features/Toys/tools/ClaudeAgent.jsx
+++ b/src/features/Toys/tools/ClaudeAgent.jsx
@@ -1,0 +1,373 @@
+import { useEffect, useRef, useState } from 'react'
+import { Field, TextArea, Btn, Note, SegmentedControl } from '../toykit'
+import { trackEvent } from '../../../utils/analytics'
+import {
+  MODELS,
+  modelFor,
+  resolveKey,
+  getStoredKey,
+  setStoredKey,
+  hasEnvKey,
+  makeClient,
+} from './claudeClient'
+
+const DEFAULT_SYSTEM =
+  'You are a research agent. Before answering, use the web_search tool to find current, accurate information — search more than once if the question has multiple parts. Ground every claim in what you find, prefer primary sources, and keep the final answer concise and factual.'
+
+// Server-side web search runs on Anthropic's infrastructure — Claude decides
+// when and what to search; results stream back. max_uses bounds cost per run.
+const WEB_SEARCH = { type: 'web_search_20250305', name: 'web_search', max_uses: 5 }
+
+const MAX_TURNS = 6 // safety bound on the pause_turn continuation loop
+
+function costFor(usage, model) {
+  const { inPrice, outPrice } = modelFor(model)
+  const input = (usage.input_tokens || 0) + (usage.cache_read_input_tokens || 0) + (usage.cache_creation_input_tokens || 0)
+  const output = usage.output_tokens || 0
+  return { inTok: input, outTok: output, usd: (input * inPrice + output * outPrice) / 1e6 }
+}
+
+function domainOf(url) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+function KeySetup({ initial, onSave }) {
+  const [value, setValue] = useState(initial || '')
+  return (
+    <div className="rounded-2xl border border-line bg-white/60 p-5">
+      <h3 className="font-serif text-lg font-semibold text-ink">Bring your own Anthropic key</h3>
+      <p className="mt-1.5 text-sm leading-relaxed text-muted">
+        The agent calls the Claude API directly from your browser, so it needs an API key. It’s
+        stored only in this browser’s local storage and sent only to{' '}
+        <code className="font-mono text-[0.8rem]">api.anthropic.com</code>. Get one from the{' '}
+        <a
+          href="https://console.anthropic.com/settings/keys"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-clay-deep underline-offset-2 hover:underline"
+        >
+          Anthropic Console
+        </a>
+        . Note: web search is a billed server tool.
+      </p>
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+        <input
+          type="password"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="sk-ant-…"
+          spellCheck={false}
+          className="w-full rounded-xl border border-line bg-white/70 px-4 py-2.5 font-mono text-[0.85rem] text-ink placeholder-muted/60 focus:border-clay focus:outline-none"
+        />
+        <Btn onClick={() => onSave(value.trim())} disabled={!value.trim()} className="shrink-0">
+          Save key
+        </Btn>
+      </div>
+    </div>
+  )
+}
+
+function SearchChip({ query }) {
+  return (
+    <div className="flex items-start gap-2.5 rounded-xl border border-line bg-white/60 px-3.5 py-2.5">
+      <i className="fas fa-magnifying-glass mt-0.5 text-sm text-ocean" aria-hidden />
+      <span className="text-[0.9rem] text-ink">
+        <span className="font-medium text-muted">Searched</span> “{query}”
+      </span>
+    </div>
+  )
+}
+
+export default function ClaudeAgent() {
+  const [key, setKey] = useState(() => resolveKey())
+  const [editingKey, setEditingKey] = useState(false)
+  const [model, setModel] = useState('claude-haiku-4-5')
+  const [thinking, setThinking] = useState(false)
+  const [system, setSystem] = useState(DEFAULT_SYSTEM)
+  const [goal, setGoal] = useState('')
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState('')
+
+  // Run state
+  const [steps, setSteps] = useState([]) // [{ kind:'search', query } | { kind:'think', text }]
+  const [sources, setSources] = useState([]) // [{ title, url }]
+  const [answer, setAnswer] = useState('')
+  const [totals, setTotals] = useState({ inTok: 0, outTok: 0, usd: 0, searches: 0 })
+
+  const streamRef = useRef(null)
+  const traceRef = useRef(null)
+
+  useEffect(() => {
+    const el = traceRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [steps, answer, running])
+
+  const saveKey = (k) => {
+    setStoredKey(k)
+    setKey(k || resolveKey())
+    setEditingKey(false)
+  }
+
+  const stop = () => streamRef.current?.abort()
+
+  const run = async () => {
+    const task = goal.trim()
+    if (!task || running || !key) return
+
+    setError('')
+    setSteps([])
+    setSources([])
+    setAnswer('')
+    setTotals({ inTok: 0, outTok: 0, usd: 0, searches: 0 })
+    setRunning(true)
+    trackEvent('toy_use', { toy_slug: 'research-agent', toy_action: 'run', model })
+
+    const addSources = (results) => {
+      if (!Array.isArray(results)) return
+      setSources((prev) => {
+        const seen = new Set(prev.map((s) => s.url))
+        const next = [...prev]
+        for (const r of results) {
+          if (r?.url && !seen.has(r.url)) {
+            seen.add(r.url)
+            next.push({ title: r.title || domainOf(r.url), url: r.url })
+          }
+        }
+        return next
+      })
+    }
+
+    const messages = [{ role: 'user', content: task }]
+
+    try {
+      const client = makeClient(key)
+      let turns = 0
+
+      while (turns++ < MAX_TURNS) {
+        const stream = client.messages.stream({
+          model,
+          max_tokens: 4096,
+          system,
+          tools: [WEB_SEARCH],
+          ...(thinking ? { thinking: { type: 'adaptive', display: 'summarized' } } : {}),
+          messages,
+        })
+        streamRef.current = stream
+
+        const blocks = {} // index -> { type, name, json }
+
+        for await (const ev of stream) {
+          if (ev.type === 'content_block_start') {
+            const b = ev.content_block
+            blocks[ev.index] = { type: b.type, name: b.name, json: '' }
+            if (b.type === 'web_search_tool_result') addSources(b.content)
+          } else if (ev.type === 'content_block_delta') {
+            if (ev.delta.type === 'text_delta') {
+              setAnswer((a) => a + ev.delta.text)
+            } else if (ev.delta.type === 'thinking_delta') {
+              setSteps((s) => {
+                const next = s.slice()
+                const last = next[next.length - 1]
+                if (last?.kind === 'think') next[next.length - 1] = { ...last, text: last.text + ev.delta.thinking }
+                else next.push({ kind: 'think', text: ev.delta.thinking })
+                return next
+              })
+            } else if (ev.delta.type === 'input_json_delta') {
+              const b = blocks[ev.index]
+              if (b) b.json += ev.delta.partial_json
+            }
+          } else if (ev.type === 'content_block_stop') {
+            const b = blocks[ev.index]
+            if (b?.type === 'server_tool_use' && b.name === 'web_search') {
+              try {
+                const q = JSON.parse(b.json).query
+                if (q) {
+                  setSteps((s) => [...s, { kind: 'search', query: q }])
+                  setTotals((t) => ({ ...t, searches: t.searches + 1 }))
+                }
+              } catch {
+                /* partial JSON — skip */
+              }
+            }
+          }
+        }
+
+        const final = await stream.finalMessage()
+        if (final?.usage) {
+          const c = costFor(final.usage, model)
+          setTotals((t) => ({ ...t, inTok: t.inTok + c.inTok, outTok: t.outTok + c.outTok, usd: t.usd + c.usd }))
+        }
+        messages.push({ role: 'assistant', content: final.content })
+
+        // Server tools may pause the turn at the internal iteration cap — re-send
+        // to let Claude continue. Any other stop reason ends the run.
+        if (final.stop_reason !== 'pause_turn') break
+      }
+    } catch (err) {
+      const aborted = err?.name === 'AbortError' || /abort/i.test(err?.message || '')
+      if (!aborted) setError(err?.message || 'Something went wrong running the agent.')
+    } finally {
+      streamRef.current = null
+      setRunning(false)
+    }
+  }
+
+  if (!key && !editingKey) {
+    return <KeySetup initial={getStoredKey()} onSave={saveKey} />
+  }
+
+  const keySource = getStoredKey() ? 'your saved key' : hasEnvKey() ? '.env.local' : 'none'
+  const idle = !running && !steps.length && !answer
+
+  return (
+    <div className="flex flex-col gap-5">
+      {editingKey && <KeySetup initial={getStoredKey()} onSave={saveKey} />}
+
+      {/* Controls */}
+      <div className="flex flex-col gap-4 rounded-2xl border border-line bg-white/50 p-4 md:flex-row md:items-end md:justify-between">
+        <div className="flex flex-wrap items-end gap-x-6 gap-y-3">
+          <Field label="Model">
+            <SegmentedControl
+              options={MODELS.map((m) => ({ value: m.id, label: m.label }))}
+              value={model}
+              onChange={setModel}
+            />
+          </Field>
+          <label className="flex cursor-pointer items-center gap-2 pb-2 text-sm font-medium text-ink-soft">
+            <input
+              type="checkbox"
+              checked={thinking}
+              onChange={(e) => setThinking(e.target.checked)}
+              className="h-4 w-4 accent-clay"
+            />
+            Extended thinking
+          </label>
+        </div>
+        <div className="flex items-center gap-3 text-xs text-muted">
+          <span className="hidden sm:inline">key: {keySource}</span>
+          <button onClick={() => setEditingKey((v) => !v)} className="font-medium hover:text-clay-deep">
+            {editingKey ? 'Close' : 'Change key'}
+          </button>
+        </div>
+      </div>
+
+      <Field label="System prompt" hint="How the agent should behave">
+        <TextArea rows={2} mono={false} value={system} onChange={(e) => setSystem(e.target.value)} />
+      </Field>
+
+      {/* Task */}
+      <Field label="Research task" hint="Enter to run, Shift+Enter for newline">
+        <div className="flex items-end gap-3">
+          <TextArea
+            rows={2}
+            mono={false}
+            value={goal}
+            onChange={(e) => setGoal(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                run()
+              }
+            }}
+            placeholder="e.g. What did Anthropic announce most recently, and when?"
+            className="flex-1"
+          />
+          {running ? (
+            <Btn variant="ghost" onClick={stop} className="shrink-0">
+              <i className="fas fa-stop" aria-hidden /> Stop
+            </Btn>
+          ) : (
+            <Btn onClick={run} disabled={!goal.trim()} className="shrink-0">
+              <i className="fas fa-wand-magic-sparkles" aria-hidden /> Run
+            </Btn>
+          )}
+        </div>
+      </Field>
+
+      {error && <Note tone="error">{error}</Note>}
+
+      {/* Trace + answer */}
+      {!idle && (
+        <div
+          ref={traceRef}
+          className="flex max-h-[60vh] flex-col gap-4 overflow-y-auto rounded-2xl border border-line bg-cream/40 p-4"
+        >
+          {/* Step timeline */}
+          {steps.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-clay">Agent steps</p>
+              {steps.map((s, i) =>
+                s.kind === 'search' ? (
+                  <SearchChip key={i} query={s.query} />
+                ) : (
+                  <details key={i} className="rounded-xl border border-line bg-white/50 px-3.5 py-2.5 text-[0.85rem]">
+                    <summary className="cursor-pointer font-medium text-muted">Thinking</summary>
+                    <p className="mt-1 whitespace-pre-wrap italic text-muted">{s.text}</p>
+                  </details>
+                )
+              )}
+              {running && (
+                <div className="flex items-center gap-2 px-1 text-sm text-muted">
+                  <i className="fas fa-circle-notch fa-spin text-ocean" aria-hidden /> Working…
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Answer */}
+          {answer && (
+            <div className="rounded-2xl border border-line bg-white/70 p-4">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-clay">Answer</p>
+              <p className="whitespace-pre-wrap text-[0.95rem] leading-relaxed text-ink">{answer}</p>
+            </div>
+          )}
+
+          {/* Sources */}
+          {sources.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-clay">
+                Sources ({sources.length})
+              </p>
+              <ol className="flex flex-col gap-1.5">
+                {sources.map((s, i) => (
+                  <li key={s.url} className="flex gap-2 text-[0.85rem] leading-snug">
+                    <span className="tabular-nums text-muted">{i + 1}.</span>
+                    <a
+                      href={s.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-ink underline-offset-2 hover:text-clay-deep hover:underline"
+                    >
+                      {s.title}
+                      <span className="ml-1.5 text-muted">— {domainOf(s.url)}</span>
+                    </a>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+        </div>
+      )}
+
+      {idle && (
+        <div className="rounded-2xl border border-dashed border-line bg-cream/30 p-6 text-center text-sm text-muted">
+          Give the agent a research task. It’ll decide what to search, run live web searches, and
+          come back with a cited answer — watch its steps as it works.
+        </div>
+      )}
+
+      {/* Usage */}
+      {(totals.outTok > 0 || totals.searches > 0) && (
+        <p className="text-right text-xs text-muted">
+          {totals.searches} {totals.searches === 1 ? 'search' : 'searches'} ·{' '}
+          {totals.inTok.toLocaleString()} in / {totals.outTok.toLocaleString()} out ·
+          ~${totals.usd < 0.01 ? totals.usd.toFixed(4) : totals.usd.toFixed(2)} (tokens; web search billed separately)
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/features/Toys/tools/ClaudeChat.jsx
+++ b/src/features/Toys/tools/ClaudeChat.jsx
@@ -1,0 +1,459 @@
+import { useEffect, useRef, useState } from 'react'
+import { Field, TextArea, Btn, Note, SegmentedControl } from '../toykit'
+import { trackEvent } from '../../../utils/analytics'
+import {
+  MODELS,
+  modelFor,
+  resolveKey,
+  getStoredKey,
+  setStoredKey,
+  hasEnvKey,
+  makeClient,
+} from './claudeClient'
+
+const DEFAULT_SYSTEM = 'You are Claude, a helpful, concise assistant.'
+
+/* Estimate cost in USD from a Messages API usage object. Cache reads bill at ~0.1x
+   input and cache writes at ~1.25x, per the pricing docs. */
+function costForTurn(usage, model) {
+  const { inPrice, outPrice } = modelFor(model)
+  const input = usage.input_tokens || 0
+  const cacheRead = usage.cache_read_input_tokens || 0
+  const cacheWrite = usage.cache_creation_input_tokens || 0
+  const output = usage.output_tokens || 0
+  const inUsd = ((input + cacheWrite * 1.25 + cacheRead * 0.1) * inPrice) / 1e6
+  const outUsd = (output * outPrice) / 1e6
+  return { inTok: input + cacheRead + cacheWrite, outTok: output, usd: inUsd + outUsd }
+}
+
+/* Build the message history one model sees. `turns` ends at the latest user turn
+   (no in-flight assistant). For each prior assistant turn, prefer this model's own
+   reply so each model stays in its own conversation; fall back to any reply so the
+   thread alternates correctly even for a model added mid-conversation. */
+function buildHistory(turns, modelId) {
+  return turns.map((t) => {
+    if (t.role === 'user') return { role: 'user', content: t.content }
+    const r =
+      t.responses.find((x) => x.model === modelId && x.content) ||
+      t.responses.find((x) => x.content)
+    return { role: 'assistant', content: r?.content || '(no response)' }
+  })
+}
+
+// Full class strings (not interpolated) so Tailwind's purge keeps them.
+const ACCENT = {
+  clay: { badge: 'bg-clay/15 text-clay-deep', dot: 'bg-clay' },
+  ocean: { badge: 'bg-ocean/15 text-ocean', dot: 'bg-ocean' },
+  sage: { badge: 'bg-sage/15 text-sage', dot: 'bg-sage' },
+}
+
+function ModelBadge({ modelId }) {
+  const m = modelFor(modelId)
+  const a = ACCENT[m.accent] || ACCENT.clay
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-semibold ${a.badge}`}
+    >
+      <span className={`h-1.5 w-1.5 rounded-full ${a.dot}`} aria-hidden />
+      {m.label}
+    </span>
+  )
+}
+
+function ResponseBody({ text, thinking, error }) {
+  return (
+    <>
+      {thinking && (
+        <details className="mb-2 text-[0.85rem]">
+          <summary className="cursor-pointer font-medium text-muted">Thinking</summary>
+          <p className="mt-1 whitespace-pre-wrap border-l-2 border-line pl-3 font-sans italic text-muted">
+            {thinking}
+          </p>
+        </details>
+      )}
+      {text && <p className="whitespace-pre-wrap">{text}</p>}
+      {error && <Note tone="error">{error}</Note>}
+      {!text && !error && (
+        <span className="inline-flex gap-1 text-muted" aria-label="Claude is typing">
+          <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
+          <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
+          <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current" />
+        </span>
+      )}
+    </>
+  )
+}
+
+function UserBubble({ text }) {
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-[85%] rounded-2xl bg-clay px-4 py-3 text-[0.95rem] leading-relaxed text-white">
+        <p className="whitespace-pre-wrap">{text}</p>
+      </div>
+    </div>
+  )
+}
+
+const GRID_COLS = { 2: 'sm:grid-cols-2', 3: 'sm:grid-cols-2 lg:grid-cols-3' }
+
+function AssistantTurn({ responses }) {
+  // Single model → a left-aligned chat bubble. Multiple → a comparison grid.
+  if (responses.length === 1) {
+    const r = responses[0]
+    return (
+      <div className="flex justify-start">
+        <div className="max-w-[85%] rounded-2xl border border-line bg-white/70 px-4 py-3 text-[0.95rem] leading-relaxed text-ink">
+          <div className="mb-1.5">
+            <ModelBadge modelId={r.model} />
+          </div>
+          <ResponseBody text={r.content} thinking={r.thinking} error={r.error} />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`grid grid-cols-1 gap-3 ${GRID_COLS[Math.min(responses.length, 3)] || ''}`}>
+      {responses.map((r) => (
+        <div
+          key={r.model}
+          className="flex flex-col rounded-2xl border border-line bg-white/70 px-4 py-3 text-[0.95rem] leading-relaxed text-ink"
+        >
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <ModelBadge modelId={r.model} />
+            {r.usage && (
+              <span className="text-[0.7rem] tabular-nums text-muted">
+                {r.usage.outTok.toLocaleString()} tok
+              </span>
+            )}
+          </div>
+          <ResponseBody text={r.content} thinking={r.thinking} error={r.error} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function KeySetup({ initial, onSave }) {
+  const [value, setValue] = useState(initial || '')
+  return (
+    <div className="rounded-2xl border border-line bg-white/60 p-5">
+      <h3 className="font-serif text-lg font-semibold text-ink">Bring your own Anthropic key</h3>
+      <p className="mt-1.5 text-sm leading-relaxed text-muted">
+        This playground calls the Claude API directly from your browser, so it needs an API key.
+        Paste one below — it’s stored only in this browser’s local storage and sent only to{' '}
+        <code className="font-mono text-[0.8rem]">api.anthropic.com</code>. Get one from the{' '}
+        <a
+          href="https://console.anthropic.com/settings/keys"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-clay-deep underline-offset-2 hover:underline"
+        >
+          Anthropic Console
+        </a>
+        .
+      </p>
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+        <input
+          type="password"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="sk-ant-…"
+          spellCheck={false}
+          className="w-full rounded-xl border border-line bg-white/70 px-4 py-2.5 font-mono text-[0.85rem] text-ink placeholder-muted/60 focus:border-clay focus:outline-none"
+        />
+        <Btn onClick={() => onSave(value.trim())} disabled={!value.trim()} className="shrink-0">
+          Save key
+        </Btn>
+      </div>
+    </div>
+  )
+}
+
+export default function ClaudeChat() {
+  const [key, setKey] = useState(() => resolveKey())
+  const [editingKey, setEditingKey] = useState(false)
+  // Default to Haiku — cheapest/fastest — so nobody racks up Opus cost by accident.
+  const [model, setModel] = useState('claude-haiku-4-5')
+  const [compare, setCompare] = useState(false)
+  const [compareModels, setCompareModels] = useState(['claude-haiku-4-5'])
+  const [thinking, setThinking] = useState(false)
+  const [system, setSystem] = useState(DEFAULT_SYSTEM)
+  const [turns, setTurns] = useState([])
+  const [input, setInput] = useState('')
+  const [streaming, setStreaming] = useState(false)
+  const [error, setError] = useState('')
+  const [totals, setTotals] = useState({ inTok: 0, outTok: 0, usd: 0 })
+
+  const streamsRef = useRef(null)
+  const scrollRef = useRef(null)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [turns, streaming])
+
+  const saveKey = (k) => {
+    setStoredKey(k)
+    setKey(k || resolveKey())
+    setEditingKey(false)
+  }
+
+  const reset = () => {
+    if (streaming) return
+    setTurns([])
+    setError('')
+    setTotals({ inTok: 0, outTok: 0, usd: 0 })
+  }
+
+  const stop = () => {
+    streamsRef.current?.forEach((s) => s.abort())
+  }
+
+  const toggleCompareModel = (id) =>
+    setCompareModels((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+
+  const activeModels = compare
+    ? MODELS.filter((m) => compareModels.includes(m.id)).map((m) => m.id) // keep palette order
+    : [model]
+
+  const send = async () => {
+    const text = input.trim()
+    if (!text || streaming || !key) return
+    if (!activeModels.length) {
+      setError('Pick at least one model.')
+      return
+    }
+
+    setError('')
+    setInput('')
+    const baseTurns = [...turns, { role: 'user', content: text }]
+    const placeholder = {
+      role: 'assistant',
+      responses: activeModels.map((m) => ({ model: m, content: '', thinking: '' })),
+    }
+    setTurns([...baseTurns, placeholder])
+    setStreaming(true)
+    trackEvent('app_use', {
+      app_slug: 'claude-chat',
+      app_action: compare ? 'compare' : 'send',
+      model: activeModels.join(','),
+    })
+
+    // Patch one model's response in the last (in-flight) assistant turn.
+    const patch = (modelId, fn) =>
+      setTurns((prev) => {
+        const next = prev.slice()
+        const last = { ...next[next.length - 1] }
+        last.responses = last.responses.map((r) => (r.model === modelId ? { ...r, ...fn(r) } : r))
+        next[next.length - 1] = last
+        return next
+      })
+
+    const streams = new Map()
+    streamsRef.current = streams
+
+    const runModel = async (modelId) => {
+      try {
+        const client = makeClient(key)
+        const stream = client.messages.stream({
+          model: modelId,
+          max_tokens: 8192,
+          system,
+          ...(thinking ? { thinking: { type: 'adaptive', display: 'summarized' } } : {}),
+          messages: buildHistory(baseTurns, modelId),
+        })
+        streams.set(modelId, stream)
+
+        for await (const event of stream) {
+          if (event.type === 'content_block_delta') {
+            if (event.delta.type === 'text_delta') {
+              patch(modelId, (r) => ({ content: r.content + event.delta.text }))
+            } else if (event.delta.type === 'thinking_delta') {
+              patch(modelId, (r) => ({ thinking: (r.thinking || '') + event.delta.thinking }))
+            }
+          }
+        }
+
+        const final = await stream.finalMessage()
+        if (final?.usage) {
+          const t = costForTurn(final.usage, modelId)
+          patch(modelId, () => ({ usage: t }))
+          setTotals((prev) => ({
+            inTok: prev.inTok + t.inTok,
+            outTok: prev.outTok + t.outTok,
+            usd: prev.usd + t.usd,
+          }))
+        }
+      } catch (err) {
+        const aborted = err?.name === 'AbortError' || /abort/i.test(err?.message || '')
+        if (!aborted) patch(modelId, () => ({ error: err?.message || 'API error.' }))
+      } finally {
+        streams.delete(modelId)
+      }
+    }
+
+    await Promise.all(activeModels.map(runModel))
+    streamsRef.current = null
+    setStreaming(false)
+  }
+
+  const onKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      send()
+    }
+  }
+
+  if (!key && !editingKey) {
+    return <KeySetup initial={getStoredKey()} onSave={saveKey} />
+  }
+
+  const keySource = getStoredKey() ? 'your saved key' : hasEnvKey() ? '.env.local' : 'none'
+
+  return (
+    <div className="flex flex-col gap-5">
+      {editingKey && <KeySetup initial={getStoredKey()} onSave={saveKey} />}
+
+      {/* Controls */}
+      <div className="flex flex-col gap-4 rounded-2xl border border-line bg-white/50 p-4">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div className="flex flex-wrap items-end gap-x-6 gap-y-3">
+            <Field label={compare ? 'Models to compare' : 'Model'}>
+              {compare ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {MODELS.map((m) => {
+                    const on = compareModels.includes(m.id)
+                    return (
+                      <button
+                        key={m.id}
+                        onClick={() => toggleCompareModel(m.id)}
+                        className={`rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${
+                          on
+                            ? 'border-transparent bg-clay text-white'
+                            : 'border-line bg-white/60 text-ink-soft hover:text-clay-deep'
+                        }`}
+                      >
+                        {m.label}
+                      </button>
+                    )
+                  })}
+                </div>
+              ) : (
+                <SegmentedControl
+                  options={MODELS.map((m) => ({ value: m.id, label: m.label }))}
+                  value={model}
+                  onChange={setModel}
+                />
+              )}
+            </Field>
+            <label className="flex cursor-pointer items-center gap-2 pb-2 text-sm font-medium text-ink-soft">
+              <input
+                type="checkbox"
+                checked={compare}
+                onChange={(e) => setCompare(e.target.checked)}
+                className="h-4 w-4 accent-clay"
+              />
+              Compare models
+            </label>
+            <label className="flex cursor-pointer items-center gap-2 pb-2 text-sm font-medium text-ink-soft">
+              <input
+                type="checkbox"
+                checked={thinking}
+                onChange={(e) => setThinking(e.target.checked)}
+                className="h-4 w-4 accent-clay"
+              />
+              Extended thinking
+            </label>
+          </div>
+          <div className="flex items-center gap-3 text-xs text-muted">
+            <span className="hidden sm:inline">key: {keySource}</span>
+            <button
+              onClick={() => setEditingKey((v) => !v)}
+              className="font-medium hover:text-clay-deep"
+            >
+              {editingKey ? 'Close' : 'Change key'}
+            </button>
+            <button
+              onClick={reset}
+              disabled={streaming || !turns.length}
+              className="font-medium hover:text-clay-deep disabled:opacity-40"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+        {compare && (
+          <p className="text-xs text-muted">
+            Each message is sent to every selected model at once; their replies stream in
+            side by side.
+          </p>
+        )}
+      </div>
+
+      <Field label="System prompt" hint="Sets Claude’s behavior for this chat">
+        <TextArea
+          rows={2}
+          mono={false}
+          value={system}
+          onChange={(e) => setSystem(e.target.value)}
+          placeholder="You are a helpful assistant…"
+        />
+      </Field>
+
+      {/* Conversation */}
+      <div
+        ref={scrollRef}
+        className="flex max-h-[60vh] min-h-[16rem] flex-col gap-3 overflow-y-auto rounded-2xl border border-line bg-cream/40 p-4"
+      >
+        {turns.length === 0 ? (
+          <div className="m-auto max-w-sm text-center text-sm text-muted">
+            Start a conversation with Claude. Pick a model — or turn on{' '}
+            <span className="font-medium text-ink-soft">Compare models</span> to send the same
+            prompt to several at once and watch their replies stream in side by side.
+          </div>
+        ) : (
+          turns.map((t, i) =>
+            t.role === 'user' ? (
+              <UserBubble key={i} text={t.content} />
+            ) : (
+              <AssistantTurn key={i} responses={t.responses} />
+            )
+          )
+        )}
+      </div>
+
+      {error && <Note tone="error">{error}</Note>}
+
+      {/* Composer */}
+      <div className="flex items-end gap-3">
+        <TextArea
+          rows={2}
+          mono={false}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Message Claude…  (Enter to send, Shift+Enter for newline)"
+          className="flex-1"
+        />
+        {streaming ? (
+          <Btn variant="ghost" onClick={stop} className="shrink-0">
+            <i className="fas fa-stop" aria-hidden /> Stop
+          </Btn>
+        ) : (
+          <Btn onClick={send} disabled={!input.trim()} className="shrink-0">
+            <i className="fas fa-paper-plane" aria-hidden /> {compare ? 'Compare' : 'Send'}
+          </Btn>
+        )}
+      </div>
+
+      {/* Usage */}
+      {totals.outTok > 0 && (
+        <p className="text-right text-xs text-muted">
+          Session: {totals.inTok.toLocaleString()} in / {totals.outTok.toLocaleString()} out ·
+          ~${totals.usd < 0.01 ? totals.usd.toFixed(4) : totals.usd.toFixed(2)}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/features/Toys/tools/claudeClient.js
+++ b/src/features/Toys/tools/claudeClient.js
@@ -1,0 +1,64 @@
+import Anthropic from '@anthropic-ai/sdk'
+
+/* Key resolution for the in-browser Claude playground.
+   Two sources, in priority order:
+     1. A key the visitor pasted in, kept in localStorage (works anywhere, incl. prod).
+     2. VITE_ANTHROPIC_API_KEY from .env.local — only present during local `npm run dev`.
+        It is NOT bundled into the GitHub Pages production build (.env.local is gitignored
+        and absent from CI), so the deployed site always falls back to bring-your-own-key.
+
+   The key never leaves the browser except in the direct call to api.anthropic.com. */
+
+const STORAGE_KEY = 'anthropic_api_key'
+
+const envKey = import.meta.env.VITE_ANTHROPIC_API_KEY || ''
+
+export function getStoredKey() {
+  try {
+    return localStorage.getItem(STORAGE_KEY) || ''
+  } catch {
+    return ''
+  }
+}
+
+export function setStoredKey(key) {
+  try {
+    if (key) localStorage.setItem(STORAGE_KEY, key)
+    else localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* storage unavailable — no-op */
+  }
+}
+
+/** The key we'll actually use: a pasted/stored key wins, else the local dev env key. */
+export function resolveKey() {
+  return getStoredKey() || envKey
+}
+
+/** True when a usable key came from .env.local rather than the visitor pasting one. */
+export function hasEnvKey() {
+  return Boolean(envKey)
+}
+
+export function makeClient(key) {
+  // dangerouslyAllowBrowser is required for a backend-less static site. It makes the
+  // SDK call the API directly from the page (and set the direct-browser-access header).
+  // Acceptable here because the key is the user's own, lives only in their browser.
+  return new Anthropic({ apiKey: key, dangerouslyAllowBrowser: true })
+}
+
+/* Models offered in the picker. Pricing is $ per 1M tokens (input / output),
+   used only for the local cost estimate. `accent` is a palette token used to
+   color-code each model's responses. */
+export const MODELS = [
+  { id: 'claude-opus-4-8', label: 'Opus 4.8', blurb: 'Most capable', accent: 'clay', inPrice: 5, outPrice: 25 },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', blurb: 'Balanced', accent: 'ocean', inPrice: 3, outPrice: 15 },
+  { id: 'claude-haiku-4-5', label: 'Haiku 4.5', blurb: 'Fastest', accent: 'sage', inPrice: 1, outPrice: 5 },
+]
+
+export function modelFor(modelId) {
+  return MODELS.find((m) => m.id === modelId) || MODELS[0]
+}
+
+// Back-compat alias — pricing helper.
+export const priceFor = modelFor

--- a/src/features/Toys/toysData.js
+++ b/src/features/Toys/toysData.js
@@ -1,3 +1,4 @@
+import { lazy } from 'react'
 import WordCounter from './tools/WordCounter'
 import TextDiff from './tools/TextDiff'
 import JsonFormatter from './tools/JsonFormatter'
@@ -8,11 +9,33 @@ import TicTacToe from './tools/TicTacToe'
 import TimeZonePicker from './tools/TimeZonePicker'
 import FlightPath from './tools/FlightPath'
 
+// Lazy so the Anthropic SDK only downloads when someone opens an AI toy.
+const ClaudeChat = lazy(() => import('./tools/ClaudeChat'))
+const ClaudeAgent = lazy(() => import('./tools/ClaudeAgent'))
+
 /* The toy registry. Adding a toy is a single entry here:
    - `Component` toys render inside the shared ToyLayout at /toys/:slug
    - `path` toys (e.g. the Zodiac) own their full page and route
    - `narrow` toys keep the reading-width column on desktop instead of the full page */
 export const toys = [
+  {
+    slug: 'claude-chat',
+    name: 'Claude Chat',
+    blurb: 'A streaming chat playground for experimenting with Claude — pick a model, set a system prompt, bring your own key.',
+    category: 'AI',
+    icon: 'fas fa-comment-dots',
+    accent: 'text-clay',
+    Component: ClaudeChat,
+  },
+  {
+    slug: 'research-agent',
+    name: 'Research Agent',
+    blurb: 'Give Claude a question and watch it run live web searches, then answer with cited sources — an agent using tools, not just a chat.',
+    category: 'AI',
+    icon: 'fas fa-robot',
+    accent: 'text-clay',
+    Component: ClaudeAgent,
+  },
   {
     slug: 'word-counter',
     name: 'Word & Character Counter',
@@ -107,7 +130,7 @@ export const toys = [
   },
 ]
 
-const CATEGORY_ORDER = ['Text', 'Developer', 'Time zones', 'Fun']
+const CATEGORY_ORDER = ['AI', 'Time zones', 'Text', 'Developer', 'Fun']
 
 export function toysByCategory() {
   return CATEGORY_ORDER.filter((c) => toys.some((t) => t.category === c)).map((category) => ({

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,23 @@
 import React from 'react'
-import ReactDOM from 'react-dom/client'
+import { hydrateRoot, createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+const root = document.getElementById('root')
+const tree = (
   <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
 )
+
+// If the page was prerendered (static HTML already in #root), hydrate it so the
+// existing markup is reused; otherwise mount fresh. Lets prerendered pages show
+// content on first paint without breaking the plain-SPA routes.
+if (root.hasChildNodes()) {
+  hydrateRoot(root, tree)
+} else {
+  createRoot(root).render(tree)
+}

--- a/src/utils/seo.js
+++ b/src/utils/seo.js
@@ -1,0 +1,174 @@
+/**
+ * Dependency-free per-route head management for the SPA.
+ *
+ * `useSeo` updates the document <title>, description, canonical link, Open Graph
+ * and Twitter tags, an optional <meta robots>, and an optional per-route
+ * JSON-LD block as the user navigates. This makes each route present correct
+ * metadata to JS-rendering crawlers (Google) and to anything that reads the DOM
+ * after hydration, on top of the static tags in index.html.
+ *
+ * Note: pure-HTML crawlers that don't run JS (some AI bots) see the static
+ * index.html head only — the homepage's Person/WebSite JSON-LD lives there.
+ */
+import { useEffect } from 'react'
+
+export const SITE_URL = 'https://zkevinbai.com'
+export const SITE_NAME = 'Kevin Bai'
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/og-image.jpg?v=2`
+
+function upsertMeta(attr, key, content) {
+  let el = document.head.querySelector(`meta[${attr}="${key}"]`)
+  if (content == null) {
+    return
+  }
+  if (!el) {
+    el = document.createElement('meta')
+    el.setAttribute(attr, key)
+    document.head.appendChild(el)
+  }
+  el.setAttribute('content', content)
+}
+
+function upsertLink(rel, href) {
+  let el = document.head.querySelector(`link[rel="${rel}"]`)
+  if (!el) {
+    el = document.createElement('link')
+    el.setAttribute('rel', rel)
+    document.head.appendChild(el)
+  }
+  el.setAttribute('href', href)
+}
+
+const ROUTE_JSONLD_ID = 'route-jsonld'
+function setRouteJsonLd(obj) {
+  let el = document.getElementById(ROUTE_JSONLD_ID)
+  if (!obj) {
+    if (el) el.remove()
+    return
+  }
+  if (!el) {
+    el = document.createElement('script')
+    el.type = 'application/ld+json'
+    el.id = ROUTE_JSONLD_ID
+    document.head.appendChild(el)
+  }
+  el.textContent = JSON.stringify(obj)
+}
+
+/** Convert a human date like "8 June 2026" to an ISO date "2026-06-08". */
+export function isoDate(human) {
+  const d = new Date(human)
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString().slice(0, 10)
+}
+
+export function useSeo({
+  title,
+  description,
+  path = '/',
+  image,
+  type = 'website',
+  robots,
+  jsonLd,
+} = {}) {
+  const ld = jsonLd ? JSON.stringify(jsonLd) : ''
+  useEffect(() => {
+    const url = SITE_URL + path
+    const img = image || DEFAULT_OG_IMAGE
+
+    if (title) document.title = title
+    if (description) upsertMeta('name', 'description', description)
+    upsertMeta('name', 'robots', robots || 'index, follow, max-image-preview:large, max-snippet:-1')
+    upsertLink('canonical', url)
+
+    upsertMeta('property', 'og:title', title)
+    upsertMeta('property', 'og:description', description)
+    upsertMeta('property', 'og:url', url)
+    upsertMeta('property', 'og:type', type)
+    upsertMeta('property', 'og:image', img)
+
+    upsertMeta('name', 'twitter:title', title)
+    upsertMeta('name', 'twitter:description', description)
+    upsertMeta('name', 'twitter:url', url)
+    upsertMeta('name', 'twitter:image', img)
+
+    setRouteJsonLd(jsonLd || null)
+    return () => setRouteJsonLd(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [title, description, path, image, type, robots, ld])
+}
+
+const AUTHOR = { '@type': 'Person', name: SITE_NAME, url: SITE_URL }
+
+/** BlogPosting schema for a single post. */
+export function articleJsonLd(post) {
+  const url = `${SITE_URL}/blog/${post.slug}`
+  const date = isoDate(post.date)
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.excerpt,
+    ...(date ? { datePublished: date, dateModified: date } : {}),
+    author: { ...AUTHOR },
+    publisher: { ...AUTHOR },
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+    image: DEFAULT_OG_IMAGE,
+    articleSection: post.category,
+    inLanguage: 'en',
+    url,
+  }
+}
+
+/** Blog index schema with the post list. */
+export function blogJsonLd(posts) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Blog',
+    name: 'Writing — Kevin Bai',
+    url: `${SITE_URL}/blog`,
+    author: { ...AUTHOR },
+    blogPost: posts.map((p) => ({
+      '@type': 'BlogPosting',
+      headline: p.title,
+      description: p.excerpt,
+      url: `${SITE_URL}/blog/${p.slug}`,
+      ...(isoDate(p.date) ? { datePublished: isoDate(p.date) } : {}),
+      articleSection: p.category,
+    })),
+  }
+}
+
+/** CollectionPage schema for an index that lists items {name, url, description}. */
+export function collectionJsonLd({ name, path, items }) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name,
+    url: SITE_URL + path,
+    isPartOf: { '@type': 'WebSite', name: SITE_NAME, url: SITE_URL },
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: items.map((it, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        url: SITE_URL + it.path,
+        name: it.name,
+      })),
+    },
+  }
+}
+
+/** WebApplication schema for an interactive tool. */
+export function softwareJsonLd({ name, description, path }) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name,
+    description,
+    url: SITE_URL + path,
+    applicationCategory: 'UtilitiesApplication',
+    operatingSystem: 'Web browser',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    author: { ...AUTHOR },
+  }
+}


### PR DESCRIPTION
## Summary

Three threads of work, all verified locally (build green, in-browser checks pass). **No visible page content was changed by the SEO/prerender work** — only metadata, structured data, and new infra files.

### 1. AI toys (Toys → AI category)
- **Claude Chat** (`/toys/claude-chat`) — streaming chat playground: model picker (Haiku default), system prompt, extended-thinking toggle, and **side-by-side multi-model compare** (fan-out to several models at once).
- **Research Agent** (`/toys/research-agent`) — an actual agent loop using Anthropic's server-side `web_search` tool: runs live searches and returns a **cited** answer with a visible step/source trace.
- Both are **lazy-loaded**, so the Anthropic SDK ships *only* on those pages — zero added weight to the homepage or any other route.
- **Keys never leave the browser**: `VITE_ANTHROPIC_API_KEY` from a local-only `.env.local` (gitignored, never in the Pages build) or a visitor-pasted key in `localStorage` (BYOK). No backend, no committed key.

### 2. SEO / GEO / discoverability
- Per-route `<head>` via a dependency-free `useSeo` hook: title, description, canonical, OG/Twitter, robots.
- Structured data: static **Person + WebSite** JSON-LD in `index.html`, plus per-route **BlogPosting / Blog / CollectionPage / WebApplication**.
- `robots.txt` explicitly welcoming AI/answer engines; build-time **`sitemap.xml`** + **`llms.txt`** (auto-include new posts/toys).

### 3. Prerendering (the GEO lever for non-JS crawlers)
- SSR-renders content routes (home, blog index, all posts, projects, curiosities) to **static HTML with content + JSON-LD baked in**; the client hydrates.
- **CI-safe**: uses React's built-in `react-dom/server` — **no new dependency**, so `npm ci` is untouched. The step is **non-fatal** (`… || echo skipped`), so any failure simply ships the existing SPA build.
- Performance: faster first paint / better Core Web Vitals; the only thing slower is the build. Homepage JS bundle unchanged.

### Content
- Refined the **Rippling** timeline entry: condensed to three bullets, added the MCP server / 10+ Skills + hiring context, copy tweaks, and a per-bullet emoji to match the Palantir entry's style.

## Verification
- `npm run build` green; prerenders 12 routes; sitemap (25 URLs) + llms.txt generated.
- In-browser (production preview): clean hydration incl. dark mode, client nav works, non-prerendered routes fall back to SPA, blog post raw HTML contains full body + JSON-LD.
- Secret scan: only `placeholder="sk-ant-…"` UI text is committed; the real key stays in gitignored `.env.local`.

> Note: I can't validate the GitHub Actions run from here, but there's no new dependency and prerendering is non-fatal, so the worst case is "ships the same SPA build as before." Worth watching the first deploy.