### PR TITLE
Add Money toys (Comp Calculator + Inflation) and Claude Vision

### DIFF
--- a/src/features/Toys/data/cpiData.js
+++ b/src/features/Toys/data/cpiData.js
@@ -1,0 +1,59 @@
+/* U.S. CPI-U annual averages (all items, U.S. city average, 1982-84 = 100),
+   from the Bureau of Labor Statistics. Used to convert dollars between years.
+
+   Conversion: an amount in year A has the same buying power as
+     amount * CPI[B] / CPI[A]
+   in year B. The most recent year is preliminary and may be revised. */
+
+export const CPI = {
+  1913: 9.9, 1914: 10.0, 1915: 10.1, 1916: 10.9, 1917: 12.8, 1918: 15.1,
+  1919: 17.3, 1920: 20.0, 1921: 17.9, 1922: 16.8, 1923: 17.1, 1924: 17.1,
+  1925: 17.5, 1926: 17.7, 1927: 17.4, 1928: 17.1, 1929: 17.1, 1930: 16.7,
+  1931: 15.2, 1932: 13.7, 1933: 13.0, 1934: 13.4, 1935: 13.7, 1936: 13.9,
+  1937: 14.4, 1938: 14.1, 1939: 13.9, 1940: 14.0, 1941: 14.7, 1942: 16.3,
+  1943: 17.3, 1944: 17.6, 1945: 18.0, 1946: 19.5, 1947: 22.3, 1948: 24.1,
+  1949: 23.8, 1950: 24.1, 1951: 26.0, 1952: 26.5, 1953: 26.7, 1954: 26.9,
+  1955: 26.8, 1956: 27.2, 1957: 28.1, 1958: 28.9, 1959: 29.1, 1960: 29.6,
+  1961: 29.9, 1962: 30.2, 1963: 30.6, 1964: 31.0, 1965: 31.5, 1966: 32.4,
+  1967: 33.4, 1968: 34.8, 1969: 36.7, 1970: 38.8, 1971: 40.5, 1972: 41.8,
+  1973: 44.4, 1974: 49.3, 1975: 53.8, 1976: 56.9, 1977: 60.6, 1978: 65.2,
+  1979: 72.6, 1980: 82.4, 1981: 90.9, 1982: 96.5, 1983: 99.6, 1984: 103.9,
+  1985: 107.6, 1986: 109.6, 1987: 113.6, 1988: 118.3, 1989: 124.0, 1990: 130.7,
+  1991: 136.2, 1992: 140.3, 1993: 144.5, 1994: 148.2, 1995: 152.4, 1996: 156.9,
+  1997: 160.5, 1998: 163.0, 1999: 166.6, 2000: 172.2, 2001: 177.1, 2002: 179.9,
+  2003: 184.0, 2004: 188.9, 2005: 195.3, 2006: 201.6, 2007: 207.342,
+  2008: 215.303, 2009: 214.537, 2010: 218.056, 2011: 224.939, 2012: 229.594,
+  2013: 232.957, 2014: 236.736, 2015: 237.017, 2016: 240.007, 2017: 245.120,
+  2018: 251.107, 2019: 255.657, 2020: 258.811, 2021: 270.970, 2022: 292.655,
+  2023: 304.702, 2024: 313.689, 2025: 322.8,
+}
+
+export const CPI_YEARS = Object.keys(CPI).map(Number).sort((a, b) => a - b)
+export const MIN_YEAR = CPI_YEARS[0]
+export const MAX_YEAR = CPI_YEARS[CPI_YEARS.length - 1]
+// The latest year is a preliminary average, flagged in the UI.
+export const PRELIMINARY_YEAR = MAX_YEAR
+
+/** Buying power of `amount` dollars from `fromYear`, expressed in `toYear` dollars. */
+export function convert(amount, fromYear, toYear) {
+  const from = CPI[fromYear]
+  const to = CPI[toYear]
+  if (!from || !to) return amount
+  return (amount * to) / from
+}
+
+/** Cumulative price change between the two years, as a fraction (0.5 = +50%). */
+export function totalInflation(fromYear, toYear) {
+  const from = CPI[fromYear]
+  const to = CPI[toYear]
+  if (!from || !to) return 0
+  return to / from - 1
+}
+
+/** Average annualized inflation rate between the years, as a fraction. */
+export function annualizedRate(fromYear, toYear) {
+  const span = toYear - fromYear
+  if (span === 0) return 0
+  const ratio = CPI[toYear] / CPI[fromYear]
+  return Math.pow(ratio, 1 / span) - 1
+}

--- a/src/features/Toys/data/taxData.js
+++ b/src/features/Toys/data/taxData.js
@@ -1,0 +1,342 @@
+/* 2025 U.S. tax data for the Comp Calculator.
+
+   Estimates only — federal brackets + FICA are exact for 2025; state tax is a
+   close approximation. It does NOT model:
+     - state credits, itemized deductions, or every state's own standard deduction
+     - local / city income taxes (NYC, Yonkers, most of Ohio, Maryland counties, …)
+     - pre-tax 401(k)/HSA, capital gains, AMT, the QBI deduction, or NIIT
+
+   For graduated states, married-filing-jointly is approximated by doubling the
+   single thresholds. That's exact for some states (CA, NY use ~2x) and a slight
+   approximation for others; the dollar effect is small at the low brackets where
+   it differs. The UI says all of this out loud.
+
+   Bracket shape: each entry { upTo, rate } means "rate applies up to upTo of
+   taxable income"; the final entry uses upTo: Infinity. Rates are percent. */
+
+// ── Federal income tax, tax year 2025 ────────────────────────────────────────
+export const FEDERAL = {
+  single: {
+    standardDeduction: 15000,
+    brackets: [
+      { upTo: 11925, rate: 10 },
+      { upTo: 48475, rate: 12 },
+      { upTo: 103350, rate: 22 },
+      { upTo: 197300, rate: 24 },
+      { upTo: 250525, rate: 32 },
+      { upTo: 626350, rate: 35 },
+      { upTo: Infinity, rate: 37 },
+    ],
+  },
+  married: {
+    standardDeduction: 30000,
+    brackets: [
+      { upTo: 23850, rate: 10 },
+      { upTo: 96950, rate: 12 },
+      { upTo: 206700, rate: 22 },
+      { upTo: 394600, rate: 24 },
+      { upTo: 501050, rate: 32 },
+      { upTo: 751600, rate: 35 },
+      { upTo: Infinity, rate: 37 },
+    ],
+  },
+}
+
+// ── FICA, 2025 ───────────────────────────────────────────────────────────────
+export const FICA = {
+  socialSecurityRate: 6.2,
+  socialSecurityWageBase: 176100,
+  medicareRate: 1.45,
+  additionalMedicareRate: 0.9, // on wages above the threshold
+  additionalMedicareThreshold: { single: 200000, married: 250000 },
+}
+
+// ── State income tax, 2025 ───────────────────────────────────────────────────
+// type: 'none' | 'flat' | 'graduated'
+//   flat:       { rate }
+//   graduated:  { brackets: [{ upTo, rate }] }  (single thresholds; MFJ doubled)
+const g = (brackets) => ({ type: 'graduated', brackets })
+const flat = (rate) => ({ type: 'flat', rate })
+const none = { type: 'none' }
+
+export const STATES = {
+  AL: { name: 'Alabama', ...g([{ upTo: 500, rate: 2 }, { upTo: 3000, rate: 4 }, { upTo: Infinity, rate: 5 }]) },
+  AK: { name: 'Alaska', ...none },
+  AZ: { name: 'Arizona', ...flat(2.5) },
+  AR: { name: 'Arkansas', ...g([{ upTo: 4400, rate: 0 }, { upTo: 8800, rate: 2 }, { upTo: Infinity, rate: 3.9 }]) },
+  CA: {
+    name: 'California',
+    ...g([
+      { upTo: 10756, rate: 1 },
+      { upTo: 25499, rate: 2 },
+      { upTo: 40245, rate: 4 },
+      { upTo: 55866, rate: 6 },
+      { upTo: 70606, rate: 8 },
+      { upTo: 360659, rate: 9.3 },
+      { upTo: 432787, rate: 10.3 },
+      { upTo: 721314, rate: 11.3 },
+      { upTo: 1000000, rate: 12.3 },
+      { upTo: Infinity, rate: 13.3 }, // +1% mental-health surtax over $1M
+    ]),
+  },
+  CO: { name: 'Colorado', ...flat(4.4) },
+  CT: {
+    name: 'Connecticut',
+    ...g([
+      { upTo: 10000, rate: 2 },
+      { upTo: 50000, rate: 4.5 },
+      { upTo: 100000, rate: 5.5 },
+      { upTo: 200000, rate: 6 },
+      { upTo: 250000, rate: 6.5 },
+      { upTo: 500000, rate: 6.9 },
+      { upTo: Infinity, rate: 6.99 },
+    ]),
+  },
+  DE: {
+    name: 'Delaware',
+    ...g([
+      { upTo: 2000, rate: 0 },
+      { upTo: 5000, rate: 2.2 },
+      { upTo: 10000, rate: 3.9 },
+      { upTo: 20000, rate: 4.8 },
+      { upTo: 25000, rate: 5.2 },
+      { upTo: 60000, rate: 5.55 },
+      { upTo: Infinity, rate: 6.6 },
+    ]),
+  },
+  FL: { name: 'Florida', ...none },
+  GA: { name: 'Georgia', ...flat(5.39) },
+  HI: {
+    name: 'Hawaii',
+    ...g([
+      { upTo: 2400, rate: 1.4 },
+      { upTo: 4800, rate: 3.2 },
+      { upTo: 9600, rate: 5.5 },
+      { upTo: 14400, rate: 6.4 },
+      { upTo: 19200, rate: 6.8 },
+      { upTo: 24000, rate: 7.2 },
+      { upTo: 36000, rate: 7.6 },
+      { upTo: 48000, rate: 7.9 },
+      { upTo: 150000, rate: 8.25 },
+      { upTo: 175000, rate: 9 },
+      { upTo: 200000, rate: 10 },
+      { upTo: Infinity, rate: 11 },
+    ]),
+  },
+  ID: { name: 'Idaho', ...flat(5.695) },
+  IL: { name: 'Illinois', ...flat(4.95) },
+  IN: { name: 'Indiana', ...flat(3.0) },
+  IA: { name: 'Iowa', ...flat(3.8) },
+  KS: { name: 'Kansas', ...g([{ upTo: 23000, rate: 5.2 }, { upTo: Infinity, rate: 5.58 }]) },
+  KY: { name: 'Kentucky', ...flat(4.0) },
+  LA: { name: 'Louisiana', ...flat(3.0) },
+  ME: { name: 'Maine', ...g([{ upTo: 26050, rate: 5.8 }, { upTo: 61600, rate: 6.75 }, { upTo: Infinity, rate: 7.15 }]) },
+  MD: {
+    name: 'Maryland',
+    ...g([
+      { upTo: 1000, rate: 2 },
+      { upTo: 2000, rate: 3 },
+      { upTo: 3000, rate: 4 },
+      { upTo: 100000, rate: 4.75 },
+      { upTo: 125000, rate: 5 },
+      { upTo: 150000, rate: 5.25 },
+      { upTo: 250000, rate: 5.5 },
+      { upTo: Infinity, rate: 5.75 },
+    ]),
+  },
+  MA: { name: 'Massachusetts', ...g([{ upTo: 1000000, rate: 5 }, { upTo: Infinity, rate: 9 }]) }, // 5% + 4% millionaire surtax
+  MI: { name: 'Michigan', ...flat(4.25) },
+  MN: {
+    name: 'Minnesota',
+    ...g([
+      { upTo: 32570, rate: 5.35 },
+      { upTo: 106990, rate: 6.8 },
+      { upTo: 198630, rate: 7.85 },
+      { upTo: Infinity, rate: 9.85 },
+    ]),
+  },
+  MS: { name: 'Mississippi', ...flat(4.4) },
+  MO: {
+    name: 'Missouri',
+    ...g([
+      { upTo: 1273, rate: 0 },
+      { upTo: 2546, rate: 2 },
+      { upTo: 3819, rate: 2.5 },
+      { upTo: 5092, rate: 3 },
+      { upTo: 6365, rate: 3.5 },
+      { upTo: 7638, rate: 4 },
+      { upTo: 8911, rate: 4.5 },
+      { upTo: Infinity, rate: 4.7 },
+    ]),
+  },
+  MT: { name: 'Montana', ...g([{ upTo: 20500, rate: 4.7 }, { upTo: Infinity, rate: 5.9 }]) },
+  NE: {
+    name: 'Nebraska',
+    ...g([{ upTo: 3700, rate: 2.46 }, { upTo: 22170, rate: 3.51 }, { upTo: 35730, rate: 5.01 }, { upTo: Infinity, rate: 5.2 }]),
+  },
+  NV: { name: 'Nevada', ...none },
+  NH: { name: 'New Hampshire', ...none }, // no tax on wages
+  NJ: {
+    name: 'New Jersey',
+    ...g([
+      { upTo: 20000, rate: 1.4 },
+      { upTo: 35000, rate: 1.75 },
+      { upTo: 40000, rate: 3.5 },
+      { upTo: 75000, rate: 5.525 },
+      { upTo: 500000, rate: 6.37 },
+      { upTo: 1000000, rate: 8.97 },
+      { upTo: Infinity, rate: 10.75 },
+    ]),
+  },
+  NM: {
+    name: 'New Mexico',
+    ...g([
+      { upTo: 5500, rate: 1.5 },
+      { upTo: 16500, rate: 3.2 },
+      { upTo: 33500, rate: 4.3 },
+      { upTo: 66500, rate: 4.7 },
+      { upTo: 210000, rate: 4.9 },
+      { upTo: Infinity, rate: 5.9 },
+    ]),
+  },
+  NY: {
+    name: 'New York',
+    ...g([
+      { upTo: 8500, rate: 4 },
+      { upTo: 11700, rate: 4.5 },
+      { upTo: 13900, rate: 5.25 },
+      { upTo: 80650, rate: 5.5 },
+      { upTo: 215400, rate: 6 },
+      { upTo: 1077550, rate: 6.85 },
+      { upTo: 5000000, rate: 9.65 },
+      { upTo: 25000000, rate: 10.3 },
+      { upTo: Infinity, rate: 10.9 },
+    ]),
+  },
+  NC: { name: 'North Carolina', ...flat(4.25) },
+  ND: { name: 'North Dakota', ...g([{ upTo: 47150, rate: 0 }, { upTo: 238200, rate: 1.95 }, { upTo: Infinity, rate: 2.5 }]) },
+  OH: { name: 'Ohio', ...g([{ upTo: 26050, rate: 0 }, { upTo: 100000, rate: 2.75 }, { upTo: Infinity, rate: 3.5 }]) },
+  OK: {
+    name: 'Oklahoma',
+    ...g([
+      { upTo: 1000, rate: 0.25 },
+      { upTo: 2500, rate: 0.75 },
+      { upTo: 3750, rate: 1.75 },
+      { upTo: 4900, rate: 2.75 },
+      { upTo: 7200, rate: 3.75 },
+      { upTo: Infinity, rate: 4.75 },
+    ]),
+  },
+  OR: {
+    name: 'Oregon',
+    ...g([{ upTo: 4300, rate: 4.75 }, { upTo: 10750, rate: 6.75 }, { upTo: 125000, rate: 8.75 }, { upTo: Infinity, rate: 9.9 }]),
+  },
+  PA: { name: 'Pennsylvania', ...flat(3.07) },
+  RI: { name: 'Rhode Island', ...g([{ upTo: 77450, rate: 3.75 }, { upTo: 176050, rate: 4.75 }, { upTo: Infinity, rate: 5.99 }]) },
+  SC: { name: 'South Carolina', ...g([{ upTo: 3460, rate: 0 }, { upTo: 17330, rate: 3 }, { upTo: Infinity, rate: 6.2 }]) },
+  SD: { name: 'South Dakota', ...none },
+  TN: { name: 'Tennessee', ...none },
+  TX: { name: 'Texas', ...none },
+  UT: { name: 'Utah', ...flat(4.55) },
+  VT: {
+    name: 'Vermont',
+    ...g([{ upTo: 45400, rate: 3.35 }, { upTo: 110050, rate: 6.6 }, { upTo: 229550, rate: 7.6 }, { upTo: Infinity, rate: 8.75 }]),
+  },
+  VA: { name: 'Virginia', ...g([{ upTo: 3000, rate: 2 }, { upTo: 5000, rate: 3 }, { upTo: 17000, rate: 5 }, { upTo: Infinity, rate: 5.75 }]) },
+  WA: { name: 'Washington', ...none }, // no wage income tax
+  WV: {
+    name: 'West Virginia',
+    ...g([
+      { upTo: 10000, rate: 2.36 },
+      { upTo: 25000, rate: 3.15 },
+      { upTo: 40000, rate: 3.54 },
+      { upTo: 60000, rate: 4.72 },
+      { upTo: Infinity, rate: 5.12 },
+    ]),
+  },
+  WI: {
+    name: 'Wisconsin',
+    ...g([{ upTo: 14680, rate: 3.5 }, { upTo: 29370, rate: 4.4 }, { upTo: 323290, rate: 5.3 }, { upTo: Infinity, rate: 7.65 }]),
+  },
+  WY: { name: 'Wyoming', ...none },
+  DC: {
+    name: 'Washington, D.C.',
+    ...g([
+      { upTo: 10000, rate: 4 },
+      { upTo: 40000, rate: 6 },
+      { upTo: 60000, rate: 6.5 },
+      { upTo: 250000, rate: 8.5 },
+      { upTo: 500000, rate: 9.25 },
+      { upTo: 1000000, rate: 9.75 },
+      { upTo: Infinity, rate: 10.75 },
+    ]),
+  },
+}
+
+// State codes sorted by full state name, for the dropdown.
+export const STATE_CODES = Object.keys(STATES).sort((a, b) =>
+  STATES[a].name.localeCompare(STATES[b].name)
+)
+
+// ── Math ─────────────────────────────────────────────────────────────────────
+
+/** Progressive tax on `income` given bracket entries { upTo, rate(percent) }. */
+export function taxFromBrackets(income, brackets) {
+  if (income <= 0) return 0
+  let tax = 0
+  let lower = 0
+  for (const { upTo, rate } of brackets) {
+    if (income <= lower) break
+    const slice = Math.min(income, upTo) - lower
+    tax += (slice * rate) / 100
+    lower = upTo
+  }
+  return tax
+}
+
+/** Federal income tax on gross wages for a filing status. */
+export function federalTax(gross, status) {
+  const f = FEDERAL[status]
+  const taxable = Math.max(0, gross - f.standardDeduction)
+  return taxFromBrackets(taxable, f.brackets)
+}
+
+/** Employee-side FICA (Social Security + Medicare + additional Medicare). */
+export function ficaTax(gross, status) {
+  const ss = Math.min(gross, FICA.socialSecurityWageBase) * (FICA.socialSecurityRate / 100)
+  const medicare = gross * (FICA.medicareRate / 100)
+  const addlBase = Math.max(0, gross - FICA.additionalMedicareThreshold[status])
+  const addl = addlBase * (FICA.additionalMedicareRate / 100)
+  return { socialSecurity: ss, medicare: medicare + addl }
+}
+
+/** State income tax. MFJ doubles graduated thresholds (see file header). */
+export function stateTax(gross, status, code) {
+  const s = STATES[code]
+  if (!s || s.type === 'none') return 0
+  if (s.type === 'flat') return gross * (s.rate / 100)
+  const brackets =
+    status === 'married'
+      ? s.brackets.map((b) => ({ upTo: b.upTo === Infinity ? Infinity : b.upTo * 2, rate: b.rate }))
+      : s.brackets
+  return taxFromBrackets(gross, brackets)
+}
+
+/** Full breakdown for an annual gross salary. All values are annual dollars. */
+export function computeTakeHome(gross, status, code) {
+  const federal = federalTax(gross, status)
+  const { socialSecurity, medicare } = ficaTax(gross, status)
+  const state = stateTax(gross, status, code)
+  const totalTax = federal + socialSecurity + medicare + state
+  const net = Math.max(0, gross - totalTax)
+  return {
+    gross,
+    federal,
+    socialSecurity,
+    medicare,
+    state,
+    totalTax,
+    net,
+    effectiveRate: gross > 0 ? (totalTax / gross) * 100 : 0,
+  }
+}

--- a/src/features/Toys/tools/ClaudeVision.jsx
+++ b/src/features/Toys/tools/ClaudeVision.jsx
@@ -1,0 +1,338 @@
+import { useEffect, useRef, useState } from 'react'
+import { Field, TextArea, Btn, Note, SegmentedControl } from '../toykit'
+import { trackEvent } from '../../../utils/analytics'
+import {
+  MODELS,
+  modelFor,
+  resolveKey,
+  getStoredKey,
+  setStoredKey,
+  hasEnvKey,
+  makeClient,
+} from './claudeClient'
+
+const ACCEPTED = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+const MAX_BYTES = 5 * 1024 * 1024 // Anthropic caps a single image at ~5MB.
+
+const PROMPTS = [
+  { label: 'Describe it', text: 'Describe this image in vivid detail.' },
+  { label: 'Extract text (OCR)', text: 'Transcribe all text in this image exactly, preserving layout where you can.' },
+  { label: 'Read the chart', text: 'Explain what this chart or diagram shows, including the key numbers and the takeaway.' },
+  { label: 'Identify objects', text: 'List the notable objects, people, and places you can identify in this image.' },
+  { label: 'Alt text', text: 'Write a concise, accessible alt-text description for this image (one sentence).' },
+]
+
+const DEFAULT_PROMPT = PROMPTS[0].text
+
+// Estimate USD for a turn from the Messages API usage object (images bill as input tokens).
+function costForTurn(usage, model) {
+  const { inPrice, outPrice } = modelFor(model)
+  const input = usage.input_tokens || 0
+  const cacheRead = usage.cache_read_input_tokens || 0
+  const cacheWrite = usage.cache_creation_input_tokens || 0
+  const output = usage.output_tokens || 0
+  const inUsd = ((input + cacheWrite * 1.25 + cacheRead * 0.1) * inPrice) / 1e6
+  const outUsd = (output * outPrice) / 1e6
+  return { inTok: input + cacheRead + cacheWrite, outTok: output, usd: inUsd + outUsd }
+}
+
+const prettyBytes = (n) => (n < 1024 * 1024 ? `${Math.round(n / 1024)} KB` : `${(n / 1048576).toFixed(1)} MB`)
+
+function KeySetup({ initial, onSave }) {
+  const [value, setValue] = useState(initial || '')
+  return (
+    <div className="rounded-2xl border border-line bg-white/60 p-5">
+      <h3 className="font-serif text-lg font-semibold text-ink">Bring your own Anthropic key</h3>
+      <p className="mt-1.5 text-sm leading-relaxed text-muted">
+        This toy calls the Claude API directly from your browser, so it needs an API key. Paste one
+        below — it’s stored only in this browser’s local storage and sent only to{' '}
+        <code className="font-mono text-[0.8rem]">api.anthropic.com</code>. Get one from the{' '}
+        <a
+          href="https://console.anthropic.com/settings/keys"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-clay-deep underline-offset-2 hover:underline"
+        >
+          Anthropic Console
+        </a>
+        .
+      </p>
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+        <input
+          type="password"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="sk-ant-…"
+          spellCheck={false}
+          className="w-full rounded-xl border border-line bg-white/70 px-4 py-2.5 font-mono text-[0.85rem] text-ink placeholder-muted/60 focus:border-clay focus:outline-none"
+        />
+        <Btn onClick={() => onSave(value.trim())} disabled={!value.trim()} className="shrink-0">
+          Save key
+        </Btn>
+      </div>
+    </div>
+  )
+}
+
+function TypingDots() {
+  return (
+    <span className="inline-flex gap-1 text-muted" aria-label="Claude is typing">
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current" />
+    </span>
+  )
+}
+
+export default function ClaudeVision() {
+  const [key, setKey] = useState(() => resolveKey())
+  const [editingKey, setEditingKey] = useState(false)
+  const [model, setModel] = useState('claude-haiku-4-5')
+  const [image, setImage] = useState(null) // { dataUrl, base64, mediaType, name, size }
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT)
+  const [dragOver, setDragOver] = useState(false)
+  const [streaming, setStreaming] = useState(false)
+  const [answer, setAnswer] = useState('')
+  const [error, setError] = useState('')
+  const [cost, setCost] = useState(null)
+
+  const fileRef = useRef(null)
+  const streamRef = useRef(null)
+
+  const loadFile = (file, source = 'file') => {
+    if (!file) return
+    if (!ACCEPTED.includes(file.type)) {
+      setError('Unsupported format. Use JPEG, PNG, GIF, or WebP.')
+      return
+    }
+    if (file.size > MAX_BYTES) {
+      setError(`That image is ${prettyBytes(file.size)} — the limit is 5 MB.`)
+      return
+    }
+    const reader = new FileReader()
+    reader.onload = () => {
+      const dataUrl = String(reader.result)
+      const base64 = dataUrl.slice(dataUrl.indexOf(',') + 1)
+      setImage({ dataUrl, base64, mediaType: file.type, name: file.name, size: file.size })
+      setAnswer('')
+      setCost(null)
+      setError('')
+      trackEvent('app_use', { app_slug: 'claude-vision', app_action: 'add_image', source })
+    }
+    reader.readAsDataURL(file)
+  }
+
+  // Paste an image from the clipboard anywhere on the page.
+  useEffect(() => {
+    const onPaste = (e) => {
+      const item = [...(e.clipboardData?.items || [])].find((i) => i.type.startsWith('image/'))
+      if (item) loadFile(item.getAsFile(), 'paste')
+    }
+    window.addEventListener('paste', onPaste)
+    return () => window.removeEventListener('paste', onPaste)
+  }, [])
+
+  const saveKey = (k) => {
+    setStoredKey(k)
+    setKey(k || resolveKey())
+    setEditingKey(false)
+  }
+
+  const stop = () => streamRef.current?.abort()
+
+  const analyze = async () => {
+    if (!image || streaming || !key) return
+    setError('')
+    setAnswer('')
+    setCost(null)
+    setStreaming(true)
+    trackEvent('app_use', { app_slug: 'claude-vision', app_action: 'analyze', model })
+
+    try {
+      const client = makeClient(key)
+      const stream = client.messages.stream({
+        model,
+        max_tokens: 4096,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                source: { type: 'base64', media_type: image.mediaType, data: image.base64 },
+              },
+              { type: 'text', text: prompt.trim() || DEFAULT_PROMPT },
+            ],
+          },
+        ],
+      })
+      streamRef.current = stream
+
+      for await (const event of stream) {
+        if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+          setAnswer((a) => a + event.delta.text)
+        }
+      }
+
+      const final = await stream.finalMessage()
+      if (final?.usage) setCost(costForTurn(final.usage, model))
+    } catch (err) {
+      const aborted = err?.name === 'AbortError' || /abort/i.test(err?.message || '')
+      if (!aborted) setError(err?.message || 'API error.')
+    } finally {
+      streamRef.current = null
+      setStreaming(false)
+    }
+  }
+
+  if (!key && !editingKey) {
+    return <KeySetup initial={getStoredKey()} onSave={saveKey} />
+  }
+
+  const keySource = getStoredKey() ? 'your saved key' : hasEnvKey() ? '.env.local' : 'none'
+
+  return (
+    <div className="flex flex-col gap-5">
+      {editingKey && <KeySetup initial={getStoredKey()} onSave={saveKey} />}
+
+      {/* Controls */}
+      <div className="flex flex-col gap-3 rounded-2xl border border-line bg-white/50 p-4 sm:flex-row sm:items-end sm:justify-between">
+        <Field label="Model">
+          <SegmentedControl
+            options={MODELS.map((m) => ({ value: m.id, label: m.label }))}
+            value={model}
+            onChange={setModel}
+          />
+        </Field>
+        <div className="flex items-center gap-3 text-xs text-muted">
+          <span className="hidden sm:inline">key: {keySource}</span>
+          <button onClick={() => setEditingKey((v) => !v)} className="font-medium hover:text-clay-deep">
+            {editingKey ? 'Close' : 'Change key'}
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-5 lg:grid-cols-2 lg:items-start">
+        {/* Image side */}
+        <div className="flex flex-col gap-3">
+          <input
+            ref={fileRef}
+            type="file"
+            accept={ACCEPTED.join(',')}
+            className="hidden"
+            onChange={(e) => loadFile(e.target.files?.[0])}
+          />
+          <div
+            onDragOver={(e) => {
+              e.preventDefault()
+              setDragOver(true)
+            }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={(e) => {
+              e.preventDefault()
+              setDragOver(false)
+              loadFile(e.dataTransfer.files?.[0], 'drop')
+            }}
+            className={`relative flex min-h-[18rem] items-center justify-center overflow-hidden rounded-2xl border-2 border-dashed p-4 text-center transition-colors ${
+              dragOver ? 'border-clay bg-clay/5' : 'border-line bg-cream/40'
+            }`}
+          >
+            {image ? (
+              <>
+                <img
+                  src={image.dataUrl}
+                  alt={image.name}
+                  className="max-h-[28rem] w-full rounded-lg object-contain"
+                />
+                <button
+                  onClick={() => {
+                    setImage(null)
+                    setAnswer('')
+                    setCost(null)
+                  }}
+                  className="absolute right-3 top-3 inline-flex h-8 w-8 items-center justify-center rounded-full border border-line bg-paper/90 text-muted shadow-sm transition-colors hover:text-clay-deep"
+                  aria-label="Remove image"
+                  title="Remove image"
+                >
+                  <i className="fas fa-times" aria-hidden />
+                </button>
+              </>
+            ) : (
+              <div className="flex flex-col items-center gap-3 text-muted">
+                <i className="fas fa-image text-3xl text-clay/70" aria-hidden />
+                <p className="text-sm leading-relaxed">
+                  Drag an image here, paste from your clipboard, or
+                </p>
+                <Btn variant="ghost" onClick={() => fileRef.current?.click()}>
+                  <i className="far fa-folder-open" aria-hidden /> Choose a file
+                </Btn>
+                <p className="text-xs text-muted/80">JPEG, PNG, GIF, or WebP · up to 5 MB</p>
+              </div>
+            )}
+          </div>
+          {image && (
+            <p className="truncate text-xs text-muted">
+              {image.name} · {prettyBytes(image.size)} ·{' '}
+              <button onClick={() => fileRef.current?.click()} className="font-medium hover:text-clay-deep">
+                replace
+              </button>
+            </p>
+          )}
+        </div>
+
+        {/* Prompt + answer side */}
+        <div className="flex flex-col gap-4">
+          <Field label="Ask about the image">
+            <TextArea
+              rows={3}
+              mono={false}
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="What would you like to know about this image?"
+            />
+          </Field>
+
+          <div className="flex flex-wrap gap-1.5">
+            {PROMPTS.map((p) => (
+              <button
+                key={p.label}
+                onClick={() => setPrompt(p.text)}
+                className="rounded-md border border-line bg-white/60 px-2.5 py-1 text-xs font-medium text-ink-soft transition-colors hover:border-clay/60 hover:text-clay-deep"
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-3">
+            {streaming ? (
+              <Btn variant="ghost" onClick={stop}>
+                <i className="fas fa-stop" aria-hidden /> Stop
+              </Btn>
+            ) : (
+              <Btn onClick={analyze} disabled={!image}>
+                <i className="fas fa-eye" aria-hidden /> Analyze
+              </Btn>
+            )}
+            {!image && <span className="text-xs text-muted">Add an image to start.</span>}
+          </div>
+
+          {error && <Note tone="error">{error}</Note>}
+
+          {(answer || streaming) && (
+            <div className="rounded-2xl border border-line bg-white/70 px-4 py-3 text-[0.95rem] leading-relaxed text-ink">
+              {answer ? <p className="whitespace-pre-wrap">{answer}</p> : <TypingDots />}
+            </div>
+          )}
+
+          {cost && (
+            <p className="text-right text-xs text-muted">
+              {cost.inTok.toLocaleString()} in / {cost.outTok.toLocaleString()} out · ~$
+              {cost.usd < 0.01 ? cost.usd.toFixed(4) : cost.usd.toFixed(2)}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/Toys/tools/CompCalculator.jsx
+++ b/src/features/Toys/tools/CompCalculator.jsx
@@ -1,0 +1,235 @@
+import { useRef, useState } from 'react'
+import { Field, TextInput, MoneyInput, SegmentedControl, Stat, Note } from '../toykit'
+import { STATES, STATE_CODES, computeTakeHome } from '../data/taxData'
+import { trackToyUse } from '../../../utils/analytics'
+
+/* Two linked tools that share one number — your annual gross.
+   Top: convert that gross across pay periods (edit any field, the rest follow).
+   Bottom: estimate take-home for a state + filing status (2025 rules). */
+
+// Pay periods. `per(h, w)` = how many of this period fit in a year, given
+// hours/week (h) and weeks/year (w) — only the hourly/daily rows use them.
+const PERIODS = [
+  { key: 'annual', label: 'Annual', per: () => 1, dp: 0 },
+  { key: 'monthly', label: 'Monthly', per: () => 12, dp: 0 },
+  { key: 'semimonthly', label: 'Semi-monthly', per: () => 24, dp: 0 },
+  { key: 'biweekly', label: 'Bi-weekly', per: () => 26, dp: 0 },
+  { key: 'weekly', label: 'Weekly', per: () => 52, dp: 0 },
+  { key: 'daily', label: 'Daily', per: (_h, w) => 5 * w, dp: 2 },
+  { key: 'hourly', label: 'Hourly', per: (h, w) => h * w, dp: 2 },
+]
+
+const usd = (n) =>
+  n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })
+
+export default function CompCalculator() {
+  const [annual, setAnnual] = useState(120000)
+  const [hours, setHours] = useState(40) // hours / week
+  const [weeks, setWeeks] = useState(52) // paid weeks / year
+
+  const [status, setStatus] = useState('single') // 'single' | 'married'
+  const [stateCode, setStateCode] = useState('CA')
+
+  // Fire one activation event the first time someone actually edits their pay —
+  // continuous keystrokes would flood analytics, so we guard with a ref.
+  const engaged = useRef(false)
+  const markEngaged = () => {
+    if (!engaged.current) {
+      engaged.current = true
+      trackToyUse('comp', 'edit_pay')
+    }
+  }
+
+  const num = (s) => {
+    const n = parseFloat(String(s).replace(/[$,\s]/g, ''))
+    return isFinite(n) ? n : 0
+  }
+
+  const take = computeTakeHome(annual, status, stateCode)
+  const stateName = STATES[stateCode].name
+  const hasStateTax = STATES[stateCode].type !== 'none'
+
+  // Stacked-bar segments: take-home + each tax, as % of gross.
+  const segments = [
+    { label: 'Take-home', value: take.net, color: 'var(--sage)' },
+    { label: 'Federal', value: take.federal, color: 'var(--clay)' },
+    { label: 'Social Security', value: take.socialSecurity, color: 'var(--clay-deep)' },
+    { label: 'Medicare', value: take.medicare, color: 'var(--gold)' },
+    { label: `${stateName} tax`, value: take.state, color: 'var(--ocean)' },
+  ].filter((s) => s.value > 0.5)
+
+  const breakdown = [
+    { label: 'Federal income tax', value: take.federal },
+    { label: 'Social Security', value: take.socialSecurity },
+    { label: 'Medicare', value: take.medicare },
+    { label: `${stateName} income tax`, value: take.state },
+  ]
+
+  return (
+    <div className="flex flex-col gap-12">
+      {/* ── Pay-period converter ─────────────────────────────────────────── */}
+      <section className="flex flex-col gap-6">
+        <div className="flex flex-col gap-1">
+          <h2 className="font-serif text-xl font-semibold text-ink">Pay period</h2>
+          <p className="text-sm text-muted">
+            Edit any amount — the rest convert instantly. Hourly and daily use your
+            hours and weeks below.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          {PERIODS.map((p) => {
+            const periods = p.per(hours, weeks)
+            const derived = periods > 0 ? annual / periods : 0
+            return (
+              <Field key={p.key} label={p.label}>
+                <MoneyInput
+                  value={derived}
+                  dp={p.dp}
+                  onValueChange={(v) => {
+                    setAnnual(v * periods)
+                    markEngaged()
+                  }}
+                />
+              </Field>
+            )
+          })}
+        </div>
+
+        <div className="flex flex-wrap gap-4">
+          <Field label="Hours / week" className="w-32">
+            <TextInput
+              inputMode="numeric"
+              value={hours}
+              onChange={(e) => setHours(num(e.target.value))}
+              className="tabular-nums"
+            />
+          </Field>
+          <Field label="Weeks / year" hint="paid" className="w-32">
+            <TextInput
+              inputMode="numeric"
+              value={weeks}
+              onChange={(e) => setWeeks(num(e.target.value))}
+              className="tabular-nums"
+            />
+          </Field>
+        </div>
+      </section>
+
+      {/* ── Take-home estimator ──────────────────────────────────────────── */}
+      <section className="flex flex-col gap-6 border-t border-line pt-10">
+        <div className="flex flex-col gap-1">
+          <h2 className="font-serif text-xl font-semibold text-ink">
+            Estimated take-home
+          </h2>
+          <p className="text-sm text-muted">
+            What lands in your pocket after federal tax, FICA, and state tax on{' '}
+            <span className="font-medium text-ink">{usd(annual)}</span> a year.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-end gap-4">
+          <Field label="State">
+            <select
+              value={stateCode}
+              onChange={(e) => {
+                setStateCode(e.target.value)
+                trackToyUse('comp', 'change_state', { state: e.target.value })
+              }}
+              className="w-56 rounded-xl border border-line bg-white/70 px-4 py-2.5 text-[0.95rem] text-ink transition-colors focus:border-clay focus:outline-none"
+            >
+              {STATE_CODES.map((c) => (
+                <option key={c} value={c}>
+                  {STATES[c].name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Filing status">
+            <SegmentedControl
+              value={status}
+              onChange={(v) => {
+                setStatus(v)
+                trackToyUse('comp', 'change_status', { status: v })
+              }}
+              options={[
+                { value: 'single', label: 'Single' },
+                { value: 'married', label: 'Married (joint)' },
+              ]}
+            />
+          </Field>
+        </div>
+
+        {!hasStateTax && (
+          <Note tone="ok">{stateName} has no state income tax on wages.</Note>
+        )}
+
+        {/* Headline net figures across periods */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Net / year" value={usd(take.net)} />
+          <Stat label="Net / month" value={usd(take.net / 12)} />
+          <Stat label="Net / paycheck (bi-weekly)" value={usd(take.net / 26)} />
+          <Stat label="Effective tax rate" value={`${take.effectiveRate.toFixed(1)}%`} />
+        </div>
+
+        {/* Stacked bar: where the gross goes */}
+        <div className="flex flex-col gap-3">
+          <div className="flex h-10 w-full overflow-hidden rounded-xl border border-line">
+            {segments.map((s) => (
+              <div
+                key={s.label}
+                style={{ width: `${(s.value / annual) * 100}%`, background: s.color }}
+                title={`${s.label}: ${usd(s.value)}`}
+              />
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-x-5 gap-y-2 text-xs">
+            {segments.map((s) => (
+              <span key={s.label} className="inline-flex items-center gap-1.5">
+                <span className="h-2.5 w-2.5 rounded-full" style={{ background: s.color }} />
+                <span className="text-ink-soft">{s.label}</span>
+                <span className="font-medium text-muted">
+                  {((s.value / annual) * 100).toFixed(1)}%
+                </span>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Line-item breakdown */}
+        <div className="flex flex-col divide-y divide-line rounded-xl border border-line bg-white/50">
+          <Row label="Gross pay" value={usd(annual)} strong />
+          {breakdown.map((b) => (
+            <Row key={b.label} label={b.label} value={`– ${usd(b.value)}`} muted />
+          ))}
+          <Row label="Total tax" value={`– ${usd(take.totalTax)}`} />
+          <Row label="Take-home pay" value={usd(take.net)} strong accent />
+        </div>
+
+        <p className="text-xs leading-relaxed text-muted">
+          Estimate only, 2025 rules. Uses standard deductions and the employee
+          share of FICA. Doesn’t model 401(k)/HSA contributions, local or city
+          taxes (NYC, etc.), credits, or itemized deductions. For graduated states,
+          married brackets are approximated by doubling the single thresholds.
+        </p>
+      </section>
+    </div>
+  )
+}
+
+function Row({ label, value, strong, muted, accent }) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+      <span className={`text-sm ${strong ? 'font-semibold text-ink' : muted ? 'text-muted' : 'text-ink-soft'}`}>
+        {label}
+      </span>
+      <span
+        className={`tabular-nums ${
+          accent ? 'font-serif text-lg font-semibold text-clay-deep' : strong ? 'font-semibold text-ink' : 'text-ink-soft'
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/src/features/Toys/tools/InflationCalculator.jsx
+++ b/src/features/Toys/tools/InflationCalculator.jsx
@@ -1,0 +1,254 @@
+import { useMemo, useRef, useState } from 'react'
+import { Field, MoneyInput, Stat, Note } from '../toykit'
+import { trackToyUse } from '../../../utils/analytics'
+import {
+  CPI,
+  MIN_YEAR,
+  MAX_YEAR,
+  PRELIMINARY_YEAR,
+  convert,
+  totalInflation,
+  annualizedRate,
+} from '../data/cpiData'
+
+const money = (n) =>
+  n.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: Math.abs(n) < 10000 ? 2 : 0,
+  })
+
+const pct = (frac) => {
+  const v = frac * 100
+  const opts = Math.abs(v) >= 1000 ? { maximumFractionDigits: 0 } : { maximumFractionDigits: 1 }
+  return v.toLocaleString('en-US', opts) + '%'
+}
+
+const QUICK_YEARS = [1950, 1970, 1980, 1990, 2000, 2010, 2020]
+
+export default function InflationCalculator() {
+  const [amount, setAmount] = useState(100)
+  const [fromYear, setFromYear] = useState(1990)
+  const [toYear, setToYear] = useState(MAX_YEAR)
+
+  // One activation event the first time someone moves a slider or edits the
+  // amount — guarded so continuous dragging doesn't flood analytics.
+  const engaged = useRef(false)
+  const markEngaged = () => {
+    if (!engaged.current) {
+      engaged.current = true
+      trackToyUse('inflation', 'adjust')
+    }
+  }
+
+  const swapYears = () => {
+    setFromYear(toYear)
+    setToYear(fromYear)
+    trackToyUse('inflation', 'swap')
+  }
+
+  const result = convert(amount, fromYear, toYear)
+  const change = totalInflation(fromYear, toYear)
+  const annual = annualizedRate(fromYear, toYear)
+  const rose = change >= 0
+  // What a single "from-year" dollar is worth in to-year dollars.
+  const dollarNow = convert(1, fromYear, toYear)
+
+  // Equivalent value of `amount` across every year in the range, for the chart.
+  const lo = Math.min(fromYear, toYear)
+  const hi = Math.max(fromYear, toYear)
+  const series = useMemo(() => {
+    const pts = []
+    for (let y = lo; y <= hi; y++) pts.push({ y, v: convert(amount, fromYear, y) })
+    return pts
+  }, [amount, fromYear, lo, hi])
+
+  return (
+    <div className="flex flex-col gap-8 lg:grid lg:grid-cols-[minmax(0,360px)_1fr] lg:items-start lg:gap-12">
+      {/* ── Controls ─────────────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-6">
+        <Field label="Amount">
+          <MoneyInput
+            value={amount}
+            dp={2}
+            onValueChange={(v) => {
+              setAmount(v)
+              markEngaged()
+            }}
+          />
+        </Field>
+
+        <YearSlider
+          label="From year"
+          value={fromYear}
+          onChange={(y) => {
+            setFromYear(y)
+            markEngaged()
+          }}
+        />
+        <div className="-my-2 flex justify-center">
+          <button
+            onClick={swapYears}
+            title="Swap years"
+            aria-label="Swap from and to years"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-line bg-white/60 text-muted transition-colors hover:border-gold/60 hover:text-ink"
+          >
+            <i className="fas fa-exchange-alt rotate-90" aria-hidden />
+          </button>
+        </div>
+        <YearSlider
+          label="To year"
+          value={toYear}
+          onChange={(y) => {
+            setToYear(y)
+            markEngaged()
+          }}
+          hint={toYear === PRELIMINARY_YEAR ? 'preliminary' : ''}
+        />
+
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted">
+            Jump “from” to
+          </span>
+          <div className="flex flex-wrap gap-1.5">
+            {QUICK_YEARS.map((y) => (
+              <button
+                key={y}
+                onClick={() => {
+                  setFromYear(y)
+                  trackToyUse('inflation', 'quick_year', { year: y })
+                }}
+                className={`rounded-md border px-2.5 py-1 text-sm font-medium tabular-nums transition-colors ${
+                  fromYear === y
+                    ? 'border-transparent bg-gold text-white'
+                    : 'border-line bg-white/60 text-ink-soft hover:border-gold/60 hover:text-ink'
+                }`}
+              >
+                {y}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Result ───────────────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-7">
+        <div className="rounded-2xl border border-line bg-cream/40 px-6 py-7">
+          <p className="text-[1.05rem] leading-relaxed text-muted">
+            <span className="font-semibold text-ink">{money(amount)}</span> in{' '}
+            <span className="font-semibold text-ink tabular-nums">{fromYear}</span> has the same
+            buying power as
+          </p>
+          <p className="mt-2 font-serif text-[2.6rem] font-semibold leading-none tracking-[-0.02em] text-clay-deep">
+            {money(result)}
+          </p>
+          <p className="mt-2 text-[1.05rem] text-muted">
+            in <span className="font-semibold text-ink tabular-nums">{toYear}</span>.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <Stat label={rose ? 'Prices rose' : 'Prices fell'} value={pct(Math.abs(change))} />
+          <Stat label="Per year, avg." value={pct(annual)} />
+          <Stat label={`$1 in ${fromYear} is now`} value={money(dollarNow)} />
+        </div>
+
+        {fromYear !== toYear && <ValueChart series={series} money={money} />}
+
+        <Note tone="muted">
+          Based on CPI-U annual averages (BLS), the standard U.S. inflation gauge.
+          {toYear === PRELIMINARY_YEAR
+            ? ` ${PRELIMINARY_YEAR} is a preliminary average and may be revised.`
+            : ''}{' '}
+          A broad market basket — your own basket (rent, tuition, electronics) can differ a lot.
+        </Note>
+      </div>
+    </div>
+  )
+}
+
+function YearSlider({ label, value, onChange, hint = '' }) {
+  return (
+    <Field label={label} hint={hint}>
+      <div className="flex items-center gap-3">
+        <span className="w-14 shrink-0 font-serif text-xl font-semibold tabular-nums text-ink">
+          {value}
+        </span>
+        <input
+          type="range"
+          min={MIN_YEAR}
+          max={MAX_YEAR}
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+          className="w-full cursor-pointer accent-gold"
+          aria-label={label}
+        />
+      </div>
+    </Field>
+  )
+}
+
+/* A small SVG line chart of the equivalent value over time, with a soft area
+   fill and labelled endpoints. Pure presentation — no axes clutter. */
+function ValueChart({ series, money }) {
+  const W = 640
+  const H = 200
+  const padX = 12
+  const padTop = 28
+  const padBottom = 24
+
+  const xs = series.map((p) => p.y)
+  const vs = series.map((p) => p.v)
+  const minX = xs[0]
+  const maxX = xs[xs.length - 1]
+  const minV = Math.min(...vs)
+  const maxV = Math.max(...vs)
+  const spanV = maxV - minV || 1
+
+  const x = (year) => padX + ((year - minX) / (maxX - minX || 1)) * (W - 2 * padX)
+  const y = (val) => padTop + (1 - (val - minV) / spanV) * (H - padTop - padBottom)
+
+  const line = series.map((p, i) => `${i ? 'L' : 'M'}${x(p.y).toFixed(1)},${y(p.v).toFixed(1)}`).join(' ')
+  const area = `${line} L${x(maxX).toFixed(1)},${H - padBottom} L${x(minX).toFixed(1)},${H - padBottom} Z`
+
+  const start = series[0]
+  const end = series[series.length - 1]
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full" role="img" aria-label="Equivalent value over time">
+      <defs>
+        <linearGradient id="inflationFill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="var(--gold)" stopOpacity="0.28" />
+          <stop offset="100%" stopColor="var(--gold)" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+
+      <path d={area} fill="url(#inflationFill)" />
+      <path d={line} fill="none" stroke="var(--gold)" strokeWidth="2.5" strokeLinejoin="round" strokeLinecap="round" />
+
+      {[start, end].map((p, i) => (
+        <g key={p.y}>
+          <circle cx={x(p.y)} cy={y(p.v)} r="4" fill="var(--clay-deep)" />
+          <text
+            x={Math.min(Math.max(x(p.y), 34), W - 34)}
+            y={y(p.v) - 12}
+            textAnchor="middle"
+            className="fill-ink"
+            style={{ fontSize: 13, fontWeight: 600 }}
+          >
+            {money(p.v)}
+          </text>
+          <text
+            x={Math.min(Math.max(x(p.y), 16), W - 16)}
+            y={H - 7}
+            textAnchor={i === 0 ? 'start' : 'end'}
+            className="fill-muted"
+            style={{ fontSize: 12 }}
+          >
+            {p.y}
+          </text>
+        </g>
+      ))}
+    </svg>
+  )
+}

--- a/src/features/Toys/toykit.jsx
+++ b/src/features/Toys/toykit.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { forwardRef, useLayoutEffect, useRef, useState } from 'react'
 
 /* Small shared building blocks so each toy stays on-brand and uncluttered.
    Everything uses the v2 paper/clay/serif tokens. */
@@ -35,14 +35,18 @@ export function TextArea({ className = '', mono = true, rows = 8, ...props }) {
   )
 }
 
-export function TextInput({ className = '', mono = false, ...props }) {
+export const TextInput = forwardRef(function TextInput(
+  { className = '', mono = false, ...props },
+  ref
+) {
   return (
     <input
+      ref={ref}
       className={`${fieldBase} ${mono ? 'font-mono text-[0.875rem]' : ''} ${className}`}
       {...props}
     />
   )
-}
+})
 
 export function Btn({ variant = 'solid', className = '', ...props }) {
   const styles = {
@@ -138,4 +142,99 @@ export function Note({ tone = 'error', children }) {
   }
   if (!children) return null
   return <p className={`text-sm font-medium ${tones[tone]}`}>{children}</p>
+}
+
+/* ── MoneyInput ──────────────────────────────────────────────────────────────
+   A currency input that shows thousands separators as you type, keeps the caret
+   where it belongs, and reports the parsed number. While focused it owns its
+   text; when blurred it reflects the derived `value` prop. */
+
+// A number → a plain numeric string (no commas), `dp` decimals, trailing zeros dropped.
+const numToStr = (n, dp) => {
+  if (!isFinite(n)) return ''
+  if (dp === 0) return String(Math.round(n))
+  return String(Number(n.toFixed(dp)))
+}
+
+// Keep only digits and a single decimal point, capped at `dp` decimals.
+const cleanNumeric = (str, dp) => {
+  let s = String(str).replace(/[^0-9.]/g, '')
+  const dot = s.indexOf('.')
+  if (dot === -1) return s
+  if (dp === 0) return s.slice(0, dot)
+  const intPart = s.slice(0, dot)
+  const decPart = s.slice(dot + 1).replace(/\./g, '').slice(0, dp)
+  return `${intPart}.${decPart}`
+}
+
+// Add thousands separators to a cleaned numeric string, preserving any decimals.
+const withCommas = (s) => {
+  if (s === '' || s === '.') return s
+  const [intPart, ...rest] = s.split('.')
+  const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+  return s.includes('.') ? `${grouped}.${rest.join('')}` : grouped
+}
+
+const countDigits = (s, end) => {
+  let n = 0
+  for (let i = 0; i < end; i++) if (s[i] >= '0' && s[i] <= '9') n++
+  return n
+}
+
+// Index in `s` just after the `count`-th digit (for caret restoration).
+const indexAfterDigit = (s, count) => {
+  if (count === 0) {
+    let i = 0
+    while (i < s.length && !(s[i] >= '0' && s[i] <= '9')) i++
+    return i
+  }
+  let seen = 0
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] >= '0' && s[i] <= '9' && ++seen === count) return i + 1
+  }
+  return s.length
+}
+
+export function MoneyInput({ value, dp = 0, onValueChange, className = '' }) {
+  const ref = useRef(null)
+  const caret = useRef(null)
+  const [focused, setFocused] = useState(false)
+  const [draft, setDraft] = useState('')
+
+  useLayoutEffect(() => {
+    if (caret.current != null && ref.current) {
+      ref.current.setSelectionRange(caret.current, caret.current)
+      caret.current = null
+    }
+  })
+
+  const display = focused ? draft : withCommas(numToStr(value, dp))
+
+  const handleChange = (e) => {
+    const el = e.target
+    const digitsBefore = countDigits(el.value, el.selectionStart ?? el.value.length)
+    const cleaned = cleanNumeric(el.value, dp)
+    const formatted = withCommas(cleaned)
+    caret.current = indexAfterDigit(formatted, digitsBefore)
+    setDraft(formatted)
+    onValueChange(cleaned === '' || cleaned === '.' ? 0 : parseFloat(cleaned))
+  }
+
+  return (
+    <div className="relative">
+      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted">$</span>
+      <TextInput
+        ref={ref}
+        inputMode="decimal"
+        value={display}
+        onChange={handleChange}
+        onFocus={() => {
+          setDraft(withCommas(numToStr(value, dp)))
+          setFocused(true)
+        }}
+        onBlur={() => setFocused(false)}
+        className={`!pl-7 tabular-nums ${className}`}
+      />
+    </div>
+  )
 }

--- a/src/features/Toys/toysData.js
+++ b/src/features/Toys/toysData.js
@@ -8,11 +8,14 @@ import SqlFormatter from './tools/SqlFormatter'
 import TicTacToe from './tools/TicTacToe'
 import TimeZonePicker from './tools/TimeZonePicker'
 import FlightPath from './tools/FlightPath'
+import CompCalculator from './tools/CompCalculator'
+import InflationCalculator from './tools/InflationCalculator'
 
 // Lazy so the Anthropic SDK only downloads when someone opens an AI toy.
 const ClaudeChat = lazy(() => import('./tools/ClaudeChat'))
 const ClaudeAgent = lazy(() => import('./tools/ClaudeAgent'))
 const ClaudeTeam = lazy(() => import('./tools/ClaudeTeam'))
+const ClaudeVision = lazy(() => import('./tools/ClaudeVision'))
 
 /* The toy registry. Adding a toy is a single entry here:
    - `Component` toys render inside the shared ToyLayout at /toys/:slug
@@ -45,6 +48,15 @@ export const toys = [
     icon: 'fas fa-sitemap',
     accent: 'text-clay',
     Component: ClaudeTeam,
+  },
+  {
+    slug: 'claude-vision',
+    name: 'Claude Vision',
+    blurb: 'Drop in any image and ask Claude about it — describe a scene, pull text out of a screenshot, read a chart, write alt text.',
+    category: 'AI',
+    icon: 'fas fa-eye',
+    accent: 'text-clay',
+    Component: ClaudeVision,
   },
   {
     slug: 'word-counter',
@@ -111,6 +123,24 @@ export const toys = [
     Component: TimeZonePicker,
   },
   {
+    slug: 'comp',
+    name: 'Comp Calculator',
+    blurb: 'Convert any salary across hourly, weekly, and monthly — then see your estimated take-home pay by state.',
+    category: 'Money',
+    icon: 'fas fa-wallet',
+    accent: 'text-gold',
+    Component: CompCalculator,
+  },
+  {
+    slug: 'inflation',
+    name: 'Inflation Time Machine',
+    blurb: 'See what a dollar from any year is worth today — buying power across a century of CPI.',
+    category: 'Money',
+    icon: 'fas fa-hand-holding-usd',
+    accent: 'text-gold',
+    Component: InflationCalculator,
+  },
+  {
     slug: 'flight-path',
     name: 'Flight Path',
     blurb: 'Pick a route and departure time — watch it arc across the map and land in local time.',
@@ -140,7 +170,7 @@ export const toys = [
   },
 ]
 
-const CATEGORY_ORDER = ['Time zones', 'Text', 'Developer', 'AI', 'Fun']
+const CATEGORY_ORDER = ['Time zones', 'Text', 'Money', 'AI', 'Developer', 'Fun']
 
 export function toysByCategory() {
   return CATEGORY_ORDER.filter((c) => toys.some((t) => t.category === c)).map((category) => ({


### PR DESCRIPTION
## What

Three new toys plus a new **Money** category.

### 💰 Comp Calculator (`/toys/comp`)
- Pay-period converter — edit any field (annual / monthly / semi-monthly / bi-weekly / weekly / daily / hourly) and the rest follow, with thousands separators that keep your caret in place.
- 2025 take-home estimator from one shared gross: real federal brackets, employee FICA (SS wage-base cap + additional Medicare), and per-state income tax for all 50 states + DC. Single / Married-jointly. Stacked breakdown + effective rate.
- Estimate-only; disclaims local taxes, 401k/HSA, credits.

### 🕰️ Inflation Time Machine (`/toys/inflation`)
- CPI-U purchasing power 1913–2025: amount + from/to year sliders, a flip button, quick-year chips, and an SVG value-over-time chart.
- Static CPI table (no API). Latest year flagged preliminary.

### 👁️ Claude Vision (`/toys/claude-vision`)
- Drag / paste / pick an image and ask Claude about it (describe, OCR, read a chart, alt text). Streams the answer. BYO key, lazy-loaded like the other AI toys.

## Plumbing
- New **Money** category; order is Time zones → Text → Money → AI → Developer → Fun.
- Promoted comma-formatting `MoneyInput` and a `forwardRef` `TextInput` into `toykit`.
- Analytics: guarded activation + funnel events on all three (`edit_pay`/`change_state`/`change_status`, `adjust`/`swap`/`quick_year`, `add_image`/`analyze`). Per-toy SEO + `toy_open` come for free via `ToyPage`.

## Verification
- `npm run build` green; 16 toys, sitemap + prerender updated.
- Verified in preview: pay-period cascade + tax math (hand-checked), inflation math + flip + chart, Vision image-load pipeline, and that every analytics event fires correctly (activation events fire exactly once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)